### PR TITLE
Parallelize keep first n

### DIFF
--- a/.github/workflows/aarch64.yaml
+++ b/.github/workflows/aarch64.yaml
@@ -21,3 +21,13 @@ jobs:
           use-cross: true
           command:   build
           args:      --target aarch64-unknown-linux-gnu
+      - uses:        actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command:   build
+          args:      --target aarch64-unknown-linux-gnu --features tokio
+      - uses:        actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command:   build
+          args:      --target aarch64-unknown-linux-gnu --features async-std

--- a/.github/workflows/arm7.yaml
+++ b/.github/workflows/arm7.yaml
@@ -21,3 +21,13 @@ jobs:
           use-cross: true
           command:   build
           args:      --target armv7-unknown-linux-gnueabihf
+      - uses:        actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command:   build
+          args:      --target armv7-unknown-linux-gnueabihf --features tokio
+      - uses:        actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command:   build
+          args:      --target armv7-unknown-linux-gnueabihf --features async-std

--- a/.github/workflows/mac_x86.yaml
+++ b/.github/workflows/mac_x86.yaml
@@ -14,10 +14,6 @@ jobs:
       - uses:        actions-rs/toolchain@v1
         with:
           toolchain: stable
-          target:    x86_64-apple-darwin
-          override:  true
-      - uses:        actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command:   build
-          args:      --target x86_64-apple-darwin
+      - run:         cargo build
+      - run:         cargo build --features tokio
+      - run:         cargo build --features async-std

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -1,24 +1,19 @@
-name:                      wasm
+name:                wasm
 
-on:                        [push]
+on:                  [push]
 
 env:
-  CARGO_TERM_COLOR:        always
-
+  CARGO_TERM_COLOR:  always
 
 jobs:
   wasm:
-    name:                  WASM Example Build
-    runs-on:               ubuntu-latest
-    defaults:
-      run:
-        shell:             bash
-        working-directory: ./examples/color-palette-picker
+    name:            WASM Build
+    runs-on:         ubuntu-latest
     steps:
-      - uses:              actions/checkout@v2
-      - uses:              actions-rs/toolchain@v1
+      - uses:        actions/checkout@v2
+      - uses:        actions-rs/toolchain@v1
         with:
-          toolchain:       stable
-          target:          wasm32-unknown-unknown
-          override:        true
-      - run:               cargo build --target wasm32-unknown-unknown --no-default-features
+          toolchain: stable
+          target:    wasm32-unknown-unknown
+          override:  true
+      - run:         cargo build --target wasm32-unknown-unknown

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -20,4 +20,4 @@ jobs:
         with:
           use-cross: true
           command:   build
-          args:      --target wasm32-unknown-unknown
+          args:      --target wasm32-unknown-unknown --no-default-features

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -1,23 +1,24 @@
-name:                wasm
+name:                      wasm
 
-on:                  [push]
+on:                        [push]
 
 env:
-  CARGO_TERM_COLOR:  always
+  CARGO_TERM_COLOR:        always
+
 
 jobs:
   wasm:
-    name:            WASM Build
-    runs-on:         ubuntu-latest
+    name:                  WASM Example Build
+    runs-on:               ubuntu-latest
+    defaults:
+      run:
+        shell:             bash
+        working-directory: ./examples/color-palette-picker
     steps:
-      - uses:        actions/checkout@v2
-      - uses:        actions-rs/toolchain@v1
+      - uses:              actions/checkout@v2
+      - uses:              actions-rs/toolchain@v1
         with:
-          toolchain: stable
-          target:    wasm32-unknown-unknown
-          override:  true
-      - uses:        actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command:   build
-          args:      --target wasm32-unknown-unknown --no-default-features
+          toolchain:       stable
+          target:          wasm32-unknown-unknown
+          override:        true
+      - run:               cargo build --target wasm32-unknown-unknown --no-default-features

--- a/.github/workflows/windows_x86.yaml
+++ b/.github/workflows/windows_x86.yaml
@@ -8,7 +8,7 @@ env:
 jobs:
   windows_x86:
     name:            Windows x86_64 Build
-    runs-on:         ubuntu-latest
+    runs-on:         windows-latest
     steps:
       - uses:        actions/checkout@v2
       - uses:        actions-rs/toolchain@v1
@@ -16,8 +16,6 @@ jobs:
           toolchain: stable
           target:    x86_64-pc-windows-gnu
           override:  true
-      - uses:        actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command:   build
-          args:      --target x86_64-pc-windows-gnu
+      - run:         cargo build
+      - run:         cargo build --features tokio
+      - run:         cargo build --features async-std

--- a/.github/workflows/x86.yaml
+++ b/.github/workflows/x86.yaml
@@ -21,3 +21,13 @@ jobs:
           use-cross: true
           command:   build
           args:      --target x86_64-unknown-linux-gnu
+      - uses:        actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command:   build
+          args:      --target x86_64-unknown-linux-gnu --features tokio
+      - uses:        actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command:   build
+          args:      --target x86_64-unknown-linux-gnu --features async-std

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,14 @@ repos:
             language:       system
             types:          [ rust ]
             pass_filenames: false
+- repo:                     local
+  hooks:
+        -   id:             readmes_synced
+            name:           READMEs synced
+            description:    Confirms the Marigold and repository READMEs have the same content.
+            entry:          bash -c 'cmp -- README.md ./marigold/README.md' --
+            language:       system
+            pass_filenames: false
 - repo:                     https://github.com/pre-commit/pre-commit-hooks
   rev:                      v3.2.0
   hooks:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ members = [
   "examples/color-palette-picker",
   "tests"
 ]
+resolver = "2"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# marigold
+# Marigold
 
 [![crates.io](https://img.shields.io/crates/v/marigold.svg)](https://crates.io/crates/marigold)
 [![docs.rs](https://img.shields.io/docsrs/marigold.svg)](https://docs.rs/marigold)
@@ -8,8 +8,9 @@
 [![wasm](https://github.com/DominicBurkart/marigold/workflows/wasm/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/wasm.yaml)
 [![last commit](https://img.shields.io/github/last-commit/dominicburkart/marigold)](https://github.com/DominicBurkart/marigold)
 
-(WIP) Marigold is a domain-specific language for data pipelining and analysis.
-Marigold compiles to asynchronous Rust, and can be accessed in a macro:
+Marigold is a domain-specific language for streaming data pipelining and
+analysis. Marigold compiles to asynchronous Rust, and can be accessed in a
+macro:
 
 ```rust
 use marigold::m;
@@ -25,3 +26,17 @@ let odd_digits = m!(
 
 println!("{:?}", odd_digits); // [1, 3, 5, 7, 9]
 ```
+
+## Runtimes
+
+By default, Marigold works in a single future and can work with any runtime.
+
+The `tokio` and `async-std` features allow Marigold to spawn additional tasks,
+enabling parallelism for multithreaded runtimes.
+
+Marigold supports async tracing, e.g. with tokio-console.
+
+## Platforms
+
+Marigold's CI builds against aarch64, arm, WASM, and x86 targets, and builds
+the x86 target in mac and windows environments.

--- a/examples/color-palette-picker/Cargo.toml
+++ b/examples/color-palette-picker/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 tokio = {version = "1", features = ["rt", "macros"]}
+async-std = {version = "1", features= ["attributes"], optional=true}
 prisma = "0.1.1"
 cute = "0.3.0"
 once_cell = "1.10.0"
@@ -13,6 +14,7 @@ console-subscriber = {version="0.1.4", optional=true }
 
 [features]
 tokio = ["dep:console-subscriber", "marigold/tokio", "tokio/rt-multi-thread", "tokio/tracing"] # parallelization using the tokio runtime
+async-std = ["marigold/async-std", "dep:async-std"] # parallelization using async-std
 
 [dependencies.marigold]
 path = "../../marigold"

--- a/examples/color-palette-picker/Cargo.toml
+++ b/examples/color-palette-picker/Cargo.toml
@@ -4,10 +4,17 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tokio = {version = "1", features = ["rt", "macros", "rt-multi-thread"]}
+tokio = {version = "1", features = ["rt", "macros", "rt-multi-thread", "tracing"]}
 prisma = "0.1.1"
 cute = "0.3.0"
 once_cell = "1.10.0"
+tracing = "0.1"
+tracing-subscriber = "0.2"
+console-subscriber = "0.1.4"
+
+[features]
+default = ["tokio-spawn"]
+tokio-spawn = ["marigold/tokio-spawn"] # parallelization using the tokio runtime
 
 [dependencies.marigold]
 path = "../../marigold"

--- a/examples/color-palette-picker/Cargo.toml
+++ b/examples/color-palette-picker/Cargo.toml
@@ -4,17 +4,16 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tokio = {version = "1", features = ["rt", "macros", "rt-multi-thread", "tracing"]}
+tokio = {version = "1", features = ["rt", "macros"]}
 prisma = "0.1.1"
 cute = "0.3.0"
 once_cell = "1.10.0"
 tracing = "0.1"
-tracing-subscriber = "0.2"
-console-subscriber = "0.1.4"
+console-subscriber = {version="0.1.4", optional=true }
 
 [features]
 default = ["tokio-spawn"]
-tokio-spawn = ["marigold/tokio-spawn"] # parallelization using the tokio runtime
+tokio-spawn = ["marigold/tokio-spawn", "dep:console-subscriber", "tokio/rt-multi-thread", "tokio/tracing"] # parallelization using the tokio runtime
 
 [dependencies.marigold]
 path = "../../marigold"

--- a/examples/color-palette-picker/Cargo.toml
+++ b/examples/color-palette-picker/Cargo.toml
@@ -12,8 +12,7 @@ tracing = "0.1"
 console-subscriber = {version="0.1.4", optional=true }
 
 [features]
-default = ["tokio-spawn"]
-tokio-spawn = ["marigold/tokio-spawn", "dep:console-subscriber", "tokio/rt-multi-thread", "tokio/tracing"] # parallelization using the tokio runtime
+tokio = ["dep:console-subscriber", "marigold/tokio", "tokio/rt-multi-thread", "tokio/tracing"] # parallelization using the tokio runtime
 
 [dependencies.marigold]
 path = "../../marigold"

--- a/examples/color-palette-picker/src/lib.rs
+++ b/examples/color-palette-picker/src/lib.rs
@@ -6,7 +6,7 @@ use prisma::{lms::LmsCam2002, FromColor, Rgb};
 
 static SRGB: Lazy<SRgb<f64>> = Lazy::new(SRgb::new);
 
-/// Returns the minimal contrast across normative triconic vision as
+/// Returns the minimal contrast across normative vision as
 /// well as red-green, blue-yellow, and total color blindness.
 fn min_contrast<T>(_colors: Vec<LmsCam2002<T>>) -> u32 {
     10 // unimplemented

--- a/examples/color-palette-picker/src/main.rs
+++ b/examples/color-palette-picker/src/main.rs
@@ -3,10 +3,10 @@ use marigold::m;
 mod lib;
 use lib::compare_contrast;
 
+/// Uses a multithread tokio runtime and tokio-console.
 #[cfg(feature = "tokio")]
 #[tokio::main]
 async fn main() {
-    #[cfg(feature = "tokio")]
     console_subscriber::init();
     println!(
         "program complete. Best colors: {:?}",
@@ -22,11 +22,28 @@ async fn main() {
     );
 }
 
-#[cfg(not(feature = "tokio"))]
+/// Uses a multithread async-std runtime.
+#[cfg(feature = "async-std")]
+#[async_std::main]
+async fn main() {
+    println!(
+        "program complete. Best colors: {:?}",
+        m!(
+            range(0, 255)
+            .permutations_with_replacement(3)
+            .combinations(2)
+            .keep_first_n(20, compare_contrast)
+            .to_vec()
+            .return
+        )
+        .await
+    );
+}
+/// Returns a single future, where all computation occurs in a single thread.
+/// This allows Marigold programs to compile with a WASM target.
+#[cfg(not(any(feature = "tokio", feature = "async-std")))]
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    #[cfg(feature = "tokio")]
-    console_subscriber::init();
     println!(
         "program complete. Best colors: {:?}",
         m!(

--- a/examples/color-palette-picker/src/main.rs
+++ b/examples/color-palette-picker/src/main.rs
@@ -3,10 +3,10 @@ use marigold::m;
 mod lib;
 use lib::compare_contrast;
 
-#[cfg(feature = "tokio-spawn")]
+#[cfg(feature = "tokio")]
 #[tokio::main]
 async fn main() {
-    #[cfg(feature = "tokio-spawn")]
+    #[cfg(feature = "tokio")]
     console_subscriber::init();
     println!(
         "program complete. Best colors: {:?}",
@@ -22,10 +22,10 @@ async fn main() {
     );
 }
 
-#[cfg(not(feature = "tokio-spawn"))]
+#[cfg(not(feature = "tokio"))]
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    #[cfg(feature = "tokio-spawn")]
+    #[cfg(feature = "tokio")]
     console_subscriber::init();
     println!(
         "program complete. Best colors: {:?}",

--- a/examples/color-palette-picker/src/main.rs
+++ b/examples/color-palette-picker/src/main.rs
@@ -5,6 +5,7 @@ use lib::compare_contrast;
 
 #[tokio::main]
 async fn main() {
+    console_subscriber::init();
     println!(
         "program complete. Best colors: {:?}",
         m!(

--- a/examples/color-palette-picker/src/main.rs
+++ b/examples/color-palette-picker/src/main.rs
@@ -3,8 +3,29 @@ use marigold::m;
 mod lib;
 use lib::compare_contrast;
 
+#[cfg(feature = "tokio-spawn")]
 #[tokio::main]
 async fn main() {
+    #[cfg(feature = "tokio-spawn")]
+    console_subscriber::init();
+    println!(
+        "program complete. Best colors: {:?}",
+        m!(
+            range(0, 255)
+            .permutations_with_replacement(3)
+            .combinations(2)
+            .keep_first_n(20, compare_contrast)
+            .to_vec()
+            .return
+        )
+        .await
+    );
+}
+
+#[cfg(not(feature = "tokio-spawn"))]
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    #[cfg(feature = "tokio-spawn")]
     console_subscriber::init();
     println!(
         "program complete. Best colors: {:?}",

--- a/marigold-grammar/src/lib.rs
+++ b/marigold-grammar/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 #[macro_use]
 extern crate lalrpop_util;
 

--- a/marigold-impl/Cargo.toml
+++ b/marigold-impl/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/DominicBurkart/marigold"
 
 [features]
 tokio = ["dep:tokio", "dep:num_cpus"]
+async-std = ["dep:async-std", "dep:num_cpus"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -21,5 +22,9 @@ gen-nested-iter-yield = "=0.1.3"
 genawaiter = {version = "0.99.1", features = ["futures03"]}
 parking_lot = "0.12.0"
 tokio = { version = "1", features = ["full", "tracing"], optional=true }
+async-std = { version = "1", optional=true}
 num_cpus = {version="1.13.1", optional=true}
 tracing = "0.1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full"]}

--- a/marigold-impl/Cargo.toml
+++ b/marigold-impl/Cargo.toml
@@ -8,8 +8,8 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/DominicBurkart/marigold"
 
 [features]
-parallel_stream = ["dep:parallel-stream", "dep:async-std"]
-
+default = ["tokio-spawn"]
+tokio-spawn = ["dep:tokio"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -21,8 +21,9 @@ binary-heap-plus = "0.4.1"
 gen-nested-iter-yield = "=0.1.3"
 genawaiter = {version = "0.99.1", features = ["futures03"]}
 parking_lot = "0.12.0"
-parallel-stream = {version="2.1.3", optional=true}
-async-std = {version = "1.11.0", features = ["tokio03"], optional=true}
+tokio = { version = "1", features = ["full", "tracing"], optional=true }
+tracing = "0.1"
+num_cpus = "1.13.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/marigold-impl/Cargo.toml
+++ b/marigold-impl/Cargo.toml
@@ -8,8 +8,7 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/DominicBurkart/marigold"
 
 [features]
-default = ["tokio-spawn"]
-tokio-spawn = ["dep:tokio"]
+tokio-spawn = ["dep:tokio", "dep:num_cpus"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -22,8 +21,5 @@ gen-nested-iter-yield = "=0.1.3"
 genawaiter = {version = "0.99.1", features = ["futures03"]}
 parking_lot = "0.12.0"
 tokio = { version = "1", features = ["full", "tracing"], optional=true }
+num_cpus = {version="1.13.1", optional=true}
 tracing = "0.1"
-num_cpus = "1.13.1"
-
-[dev-dependencies]
-tokio = { version = "1", features = ["rt", "macros"] }

--- a/marigold-impl/Cargo.toml
+++ b/marigold-impl/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/DominicBurkart/marigold"
 
 [features]
-tokio-spawn = ["dep:tokio", "dep:num_cpus"]
+tokio = ["dep:tokio", "dep:num_cpus"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/marigold-impl/Cargo.toml
+++ b/marigold-impl/Cargo.toml
@@ -19,7 +19,7 @@ gen-nested-iter-yield = "=0.1.3"
 genawaiter = {version = "0.99.1", features = ["futures03"]}
 parking_lot = "0.12.0"
 parallel-stream = "2.1.3"
-async-std = "1.11.0"
+async-std = {version = "1.11.0", features = ["tokio3"]}
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/marigold-impl/Cargo.toml
+++ b/marigold-impl/Cargo.toml
@@ -19,7 +19,7 @@ gen-nested-iter-yield = "=0.1.3"
 genawaiter = {version = "0.99.1", features = ["futures03"]}
 parking_lot = "0.12.0"
 parallel-stream = "2.1.3"
-
+async-std = "1.11.0"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/marigold-impl/Cargo.toml
+++ b/marigold-impl/Cargo.toml
@@ -7,6 +7,9 @@ description = "Internal logic for the marigold language."
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/DominicBurkart/marigold"
 
+[features]
+parallel_stream = ["dep:parallel-stream", "dep:async-std"]
+
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -18,8 +21,8 @@ binary-heap-plus = "0.4.1"
 gen-nested-iter-yield = "=0.1.3"
 genawaiter = {version = "0.99.1", features = ["futures03"]}
 parking_lot = "0.12.0"
-parallel-stream = "2.1.3"
-async-std = {version = "1.11.0", features = ["tokio3"]}
+parallel-stream = {version="2.1.3", optional=true}
+async-std = {version = "1.11.0", features = ["tokio03"], optional=true}
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/marigold-impl/Cargo.toml
+++ b/marigold-impl/Cargo.toml
@@ -18,6 +18,7 @@ binary-heap-plus = "0.4.1"
 gen-nested-iter-yield = "=0.1.3"
 genawaiter = {version = "0.99.1", features = ["futures03"]}
 parking_lot = "0.12.0"
+parallel-stream = "2.1.3"
 
 
 [dev-dependencies]

--- a/marigold-impl/src/async_runtime.rs
+++ b/marigold-impl/src/async_runtime.rs
@@ -1,0 +1,17 @@
+#[cfg(feature = "tokio")]
+pub fn spawn<T>(future: T) -> tokio::task::JoinHandle<T::Output>
+where
+    T: std::future::Future + Send + 'static,
+    T::Output: Send + 'static,
+{
+    tokio::spawn(future)
+}
+
+#[cfg(feature = "async-std")]
+pub fn spawn<T>(future: T) -> async_std::task::JoinHandle<T::Output>
+where
+    T: std::future::Future + Send + 'static,
+    T::Output: Send + 'static,
+{
+    async_std::task::spawn(future)
+}

--- a/marigold-impl/src/collect_and_apply.rs
+++ b/marigold-impl/src/collect_and_apply.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use futures::stream::Stream;
 use futures::StreamExt;
+use tracing::instrument;
 
 #[async_trait]
 pub trait CollectAndAppliable<T, U, F>
@@ -14,10 +15,11 @@ where
 #[async_trait]
 impl<SInput, T, U, F> CollectAndAppliable<T, U, F> for SInput
 where
-    SInput: Stream<Item = T> + Send + Unpin,
-    T: Clone + Send,
+    SInput: Stream<Item = T> + Send + Unpin + std::fmt::Debug,
+    T: Clone + Send + std::fmt::Debug,
     F: std::marker::Send + Fn(Vec<T>) -> U + 'static,
 {
+    #[instrument(skip(self, f))]
     async fn collect_and_apply(mut self, f: F) -> U {
         let values = self.collect::<Vec<_>>().await;
         f(values)

--- a/marigold-impl/src/combinations.rs
+++ b/marigold-impl/src/combinations.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use futures::stream::Stream;
 use futures::stream::StreamExt;
 use itertools::Combinations;
+use tracing::instrument;
 
 #[async_trait]
 pub trait Combinable<T> {
@@ -17,8 +18,9 @@ pub trait Combinable<T> {
 impl<T, SInput> Combinable<T> for SInput
 where
     SInput: Stream<Item = T> + Send,
-    T: Clone + Send,
+    T: Clone + Send + std::fmt::Debug,
 {
+    #[instrument(skip(self))]
     async fn combinations(
         self,
         k: usize,

--- a/marigold-impl/src/keep_first_n.rs
+++ b/marigold-impl/src/keep_first_n.rs
@@ -21,6 +21,7 @@ where
     ) -> futures::stream::Iter<std::vec::IntoIter<T>>;
 }
 
+#[cfg(feature = "parallel_stream")]
 #[async_trait]
 impl<SInput, T, F> KeepFirstN<T, F> for SInput
 where
@@ -43,6 +44,7 @@ where
 /// type of the binary heap, which includes a lambda for reversing the ordering fromt the passed
 /// sort_by function. By declaring a new function, we can use generics to describe its type, and
 /// then can use that type while unsafely casting pointers.
+#[cfg(feature = "parallel_stream")]
 async fn impl_keep_first_n<SInput, T, F, FReversed>(
     mut sinput: SInput,
     mut first_n: BinaryHeap<T, binary_heap_plus::FnComparator<FReversed>>,
@@ -111,6 +113,63 @@ where
             .into_sorted_vec()
             .into_iter(),
     )
+}
+
+#[async_trait]
+#[cfg(not(feature = "parallel_stream"))]
+impl<SInput, T, F> KeepFirstN<T, F> for SInput
+where
+    SInput: Stream<Item = T> + Send + Unpin,
+    T: Clone + Send + std::marker::Sync,
+    F: Fn(&T, &T) -> Ordering + std::marker::Send + std::marker::Sync + 'static,
+{
+    async fn keep_first_n(
+        mut self,
+        n: usize,
+        sorted_by: F,
+    ) -> futures::stream::Iter<std::vec::IntoIter<T>> {
+        // use the reverse ordering so that the smallest value is always the first to pop.
+        let mut first_n = BinaryHeap::with_capacity_by(n, |a, b| match sorted_by(a, b) {
+            Ordering::Less => Ordering::Greater,
+            Ordering::Equal => Ordering::Equal,
+            Ordering::Greater => Ordering::Less,
+        });
+
+        while first_n.len() < n {
+            if let Some(item) = self.next().await {
+                first_n.push(item);
+            } else {
+                break;
+            }
+        }
+
+        // If we have exhausted the stream before reaching n values, we can exit early.
+        if first_n.len() < n {
+            return futures::stream::iter(first_n.into_sorted_vec().into_iter());
+        }
+
+        // Otherwise, we can check each remaining value in the stream against the smallest
+        // kept value, updating the kept values only when a keepable value is found.
+        let first_n_mutex = parking_lot::Mutex::new(first_n);
+        let smallest_kept =
+            parking_lot::RwLock::new(first_n_mutex.lock().peek().unwrap().to_owned());
+
+        self.for_each_concurrent(
+            /* arbitrarily set concurrency limit */ 256,
+            |item| async {
+                if sorted_by(&*smallest_kept.read(), &item) == Ordering::Less {
+                    let mut first_n_mut = first_n_mutex.lock();
+                    first_n_mut.pop();
+                    first_n_mut.push(item);
+                    let mut update_smallest_kept = smallest_kept.write();
+                    *update_smallest_kept = first_n_mut.peek().unwrap().to_owned();
+                }
+            },
+        )
+        .await;
+
+        futures::stream::iter(first_n_mutex.into_inner().into_sorted_vec().into_iter())
+    }
 }
 
 #[cfg(test)]

--- a/marigold-impl/src/keep_first_n.rs
+++ b/marigold-impl/src/keep_first_n.rs
@@ -3,7 +3,7 @@ use binary_heap_plus::BinaryHeap;
 use futures::stream::Stream;
 use futures::stream::StreamExt;
 use std::cmp::Ordering;
-#[cfg(feature = "tokio-spawn")]
+#[cfg(feature = "tokio")]
 use std::ops::Deref;
 use tracing::instrument;
 
@@ -21,7 +21,7 @@ where
     ) -> futures::stream::Iter<std::vec::IntoIter<T>>;
 }
 
-#[cfg(feature = "tokio-spawn")]
+#[cfg(feature = "tokio")]
 #[async_trait]
 impl<SInput, T, F> KeepFirstN<T, F> for SInput
 where
@@ -45,7 +45,7 @@ where
 /// type of the binary heap, which includes a lambda for reversing the ordering fromt the passed
 /// sort_by function. By declaring a new function, we can use generics to describe its type, and
 /// then can use that type while unsafely casting pointers.
-#[cfg(feature = "tokio-spawn")]
+#[cfg(feature = "tokio")]
 async fn impl_keep_first_n<SInput, T, F, FReversed>(
     mut sinput: SInput,
     mut first_n: BinaryHeap<T, binary_heap_plus::FnComparator<FReversed>>,
@@ -109,7 +109,7 @@ where
 }
 
 #[async_trait]
-#[cfg(not(feature = "tokio-spawn"))]
+#[cfg(not(feature = "tokio"))]
 impl<SInput, T, F> KeepFirstN<T, F> for SInput
 where
     SInput: Stream<Item = T> + Send + Unpin,

--- a/marigold-impl/src/lib.rs
+++ b/marigold-impl/src/lib.rs
@@ -1,4 +1,5 @@
 pub use futures;
+mod async_runtime;
 pub mod collect_and_apply;
 pub mod combinations;
 pub mod keep_first_n;

--- a/marigold-impl/src/lib.rs
+++ b/marigold-impl/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 pub use futures;
 mod async_runtime;
 pub mod collect_and_apply;

--- a/marigold-impl/src/permutations.rs
+++ b/marigold-impl/src/permutations.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use futures::stream::Stream;
 use futures::stream::StreamExt;
 use itertools::Permutations;
+use tracing::instrument;
 
 #[async_trait]
 pub trait Permutable<T> {
@@ -17,8 +18,9 @@ pub trait Permutable<T> {
 impl<T, SInput> Permutable<T> for SInput
 where
     SInput: Stream<Item = T> + Send,
-    T: Clone + Send,
+    T: Clone + Send + std::fmt::Debug,
 {
+    #[instrument(skip(self))]
     async fn permutations(
         self,
         k: usize,

--- a/marigold-impl/src/to_vec.rs
+++ b/marigold-impl/src/to_vec.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use futures::Stream;
 use futures::StreamExt;
+use tracing::instrument;
 
 #[async_trait]
 pub trait Vectable<T> {
@@ -12,8 +13,9 @@ pub trait Vectable<T> {
 impl<T, SInput> Vectable<T> for SInput
 where
     SInput: Stream<Item = T> + Send,
-    T: Clone + Send,
+    T: Clone + Send + std::fmt::Debug,
 {
+    #[instrument(skip(self))]
     async fn to_vec(self) -> Vec<T> {
         self.collect::<Vec<_>>().await
     }

--- a/marigold-macros/src/lib.rs
+++ b/marigold-macros/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 extern crate proc_macro;
 use marigold_grammar::marigold_parse;
 use proc_macro::TokenStream;

--- a/marigold/Cargo.toml
+++ b/marigold/Cargo.toml
@@ -8,12 +8,11 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/DominicBurkart/marigold"
 
 [features]
-default = ["parallel"]
-parallel = ["marigold-impl/parallel_stream"]
+default = ["tokio-spawn"]
+tokio-spawn = ["marigold-impl/tokio-spawn"]
 
 [dependencies]
 anyhow = "1.0"
-tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread"] }
 
 [dependencies.marigold-grammar]
 path = "../marigold-grammar"
@@ -26,3 +25,6 @@ version = "=0.1.8"
 [dependencies.marigold-impl]
 path = "../marigold-impl"
 version = "=0.1.8"
+
+[dev-dependencies]
+tokio = {version = "1", features = ["full"]}

--- a/marigold/Cargo.toml
+++ b/marigold/Cargo.toml
@@ -8,7 +8,6 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/DominicBurkart/marigold"
 
 [features]
-default = ["tokio-spawn"]
 tokio-spawn = ["marigold-impl/tokio-spawn"]
 
 [dependencies]

--- a/marigold/Cargo.toml
+++ b/marigold/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/DominicBurkart/marigold"
 
 [features]
-tokio-spawn = ["marigold-impl/tokio-spawn"]
+tokio = ["marigold-impl/tokio"]
 
 [dependencies]
 anyhow = "1.0"

--- a/marigold/Cargo.toml
+++ b/marigold/Cargo.toml
@@ -7,7 +7,9 @@ description = "The Marigold Programming Language."
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/DominicBurkart/marigold"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = ["parallel"]
+parallel = ["marigold-impl/parallel_stream"]
 
 [dependencies]
 anyhow = "1.0"

--- a/marigold/Cargo.toml
+++ b/marigold/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/DominicBurkart/marigold"
 
 [features]
 tokio = ["marigold-impl/tokio"]
+async-std = ["marigold-impl/async-std"]
 
 [dependencies]
 anyhow = "1.0"

--- a/marigold/README.md
+++ b/marigold/README.md
@@ -1,4 +1,4 @@
-# marigold
+# Marigold
 
 [![crates.io](https://img.shields.io/crates/v/marigold.svg)](https://crates.io/crates/marigold)
 [![docs.rs](https://img.shields.io/docsrs/marigold.svg)](https://docs.rs/marigold)
@@ -8,8 +8,9 @@
 [![wasm](https://github.com/DominicBurkart/marigold/workflows/wasm/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/wasm.yaml)
 [![last commit](https://img.shields.io/github/last-commit/dominicburkart/marigold)](https://github.com/DominicBurkart/marigold)
 
-(WIP) Marigold is a domain-specific language for data pipelining and analysis.
-Marigold compiles to asynchronous Rust, and can be accessed in a macro:
+Marigold is a domain-specific language for streaming data pipelining and
+analysis. Marigold compiles to asynchronous Rust, and can be accessed in a
+macro:
 
 ```rust
 use marigold::m;
@@ -25,3 +26,17 @@ let odd_digits = m!(
 
 println!("{:?}", odd_digits); // [1, 3, 5, 7, 9]
 ```
+
+## Runtimes
+
+By default, Marigold works in a single future and can work with any runtime.
+
+The `tokio` and `async-std` features allow Marigold to spawn additional tasks,
+enabling parallelism for multithreaded runtimes.
+
+Marigold supports async tracing, e.g. with tokio-console.
+
+## Platforms
+
+Marigold's CI builds against aarch64, arm, WASM, and x86 targets, and builds
+the x86 target in mac and windows environments.

--- a/marigold/src/lib.rs
+++ b/marigold/src/lib.rs
@@ -20,6 +20,7 @@
 //! assert_eq!(odd_digits, vec![1, 3, 5, 7, 9]);
 //! # }
 //! ```
+#![forbid(unsafe_code)]
 
 pub use crate as marigold; // used so that the tests can reference re-exported values
 pub use marigold_impl;


### PR DESCRIPTION
- support parallelization of keep first n for multithreaded tokio and async-std runtimes
- add `tokio` and `async-std` features
- [merged from separate PR] adding tracing
- update readme
- update CI to compile without features, with async-std, and with tokio on every platform except wasm (multiprocessing not supported on wasm)
- forbid unsafe code in all marigold libraries