### PR TITLE
implement multi-streams

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "marigold-impl",
   "examples/color-palette-picker",
   "examples/csv",
+  "examples/multi-consumer",
   "tests"
 ]
 resolver = "2"

--- a/examples/multi-consumer/Cargo.toml
+++ b/examples/multi-consumer/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-tokio = ["marigold/tokio"]
+tokio = ["marigold/tokio", "tokio/rt-multi-thread"]
 async-std = ["dep:async-std", "marigold/async-std"]
 
 [dependencies]
 async-std = {version = "1", features= ["attributes"], optional=true}
-tokio = {version = "1", features = ["rt", "rt-multi-thread", "macros"]}
+tokio = {version = "1", features = ["rt", "macros"]}
 
 [dependencies.marigold]
 path = "../../marigold"

--- a/examples/multi-consumer/Cargo.toml
+++ b/examples/multi-consumer/Cargo.toml
@@ -3,11 +3,14 @@ name = "multi-consumer"
 version = "0.1.0"
 edition = "2021"
 
-[dependencies.tokio]
-version = "1"
-features = ["rt", "rt-multi-thread", "macros"]
+[features]
+tokio = ["marigold/tokio"]
+async-std = ["dep:async-std", "marigold/async-std"]
+
+[dependencies]
+async-std = {version = "1", features= ["attributes"], optional=true}
+tokio = {version = "1", features = ["rt", "rt-multi-thread", "macros"]}
 
 [dependencies.marigold]
 path = "../../marigold"
 version = "=0.1.11"
-features = ["tokio"]

--- a/examples/multi-consumer/Cargo.toml
+++ b/examples/multi-consumer/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "multi-consumer"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies.tokio]
+version = "1"
+features = ["rt", "rt-multi-thread", "macros"]
+
+[dependencies.marigold]
+path = "../../marigold"
+version = "=0.1.11"
+features = ["tokio"]

--- a/examples/multi-consumer/src/main.rs
+++ b/examples/multi-consumer/src/main.rs
@@ -43,7 +43,20 @@ async fn run() {
     println!("result: {:?}", small_even_number_set);
 }
 
+#[cfg(feature = "tokio")]
 #[tokio::main]
+async fn main() {
+    run().await
+}
+
+#[cfg(feature = "async-std")]
+#[async_std::main]
+async fn main() {
+    run().await
+}
+
+#[cfg(not(any(feature = "async-std", feature = "tokio")))]
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
     run().await
 }
@@ -52,7 +65,14 @@ async fn main() {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "tokio")]
     #[tokio::test]
+    async fn multi_consumer() {
+        run().await;
+    }
+
+    #[cfg(feature = "async-std")]
+    #[async_std::test]
     async fn multi_consumer() {
         run().await;
     }

--- a/examples/multi-consumer/src/main.rs
+++ b/examples/multi-consumer/src/main.rs
@@ -65,7 +65,7 @@ async fn main() {
 mod tests {
     use super::*;
 
-    #[cfg(feature = "tokio")]
+    #[cfg(not(feature = "async-std"))]
     #[tokio::test]
     async fn multi_consumer() {
         run().await;

--- a/examples/multi-consumer/src/main.rs
+++ b/examples/multi-consumer/src/main.rs
@@ -1,0 +1,59 @@
+use marigold::m;
+use marigold::marigold_impl::StreamExt;
+use std::collections::HashSet;
+
+fn is_odd(i: &i32) -> bool {
+    i % 2 == 1
+}
+
+fn is_even(i: &i32) -> bool {
+    i % 2 == 0
+}
+
+fn doubled_plus_ten(i: i32) -> i32 {
+    (i * 2) + 10
+}
+
+async fn run() {
+    let some_small_even_numbers = m!(
+        digits = range(0, 10)
+
+        digits
+            .filter(is_even)
+            .return
+
+        odd_digits = digits
+            .filter(is_odd)
+
+        odd_digits
+            .map(doubled_plus_ten)
+            .return
+    )
+    .await;
+
+    let small_even_number_set = some_small_even_numbers.collect::<HashSet<i32>>().await;
+
+    assert_eq!(
+        small_even_number_set,
+        [0, 2, 4, 6, 8, 12, 16, 20, 24, 28]
+            .into_iter()
+            .collect::<HashSet<i32>>()
+    );
+
+    println!("result: {:?}", small_even_number_set);
+}
+
+#[tokio::main]
+async fn main() {
+    run().await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn multi_consumer() {
+        run().await;
+    }
+}

--- a/marigold-grammar/src/ast.lalrpop
+++ b/marigold-grammar/src/ast.lalrpop
@@ -162,7 +162,7 @@ pub Program: String = {
       );
       output.push_str(format!("let streams_array = typed_stream_vec({streams_string});").as_str());
     } else {
-      output.push_str(format!("let streams_array:  Vec<core::pin::Pin<dyn futures::Stream<Item=()>>> = {streams_string};").as_str());
+      output.push_str(format!("let streams_array:  Vec<core::pin::Pin<Box<dyn futures::Stream<Item=()>>>> = {streams_string};").as_str());
     }
 
     output.push_str("let mut all_streams = ::marigold::marigold_impl::futures::stream::select_all(streams_array);");

--- a/marigold-grammar/src/ast.lalrpop
+++ b/marigold-grammar/src/ast.lalrpop
@@ -1,63 +1,147 @@
 use crate::nodes;
 use std::str::FromStr;
+use itertools::Itertools;
 
 grammar;
 
 pub Program: String = {
   Expr* => {
-    let n_streams = <>
-      .iter()
-      .filter(
-        |exp|
-          exp.placement == nodes::Placement::ReturningStream ||
-          exp.placement == nodes::Placement::StreamWithoutSpecificPlacement
-      )
-      .count();
-
-    let mut expressions = std::collections::HashMap::new();
-    <>
-      .into_iter()
-      .for_each(
-        |expression|
-          expressions
-            .entry(expression.placement)
-            .or_insert(Vec::new())
-            .push(expression.code)
-      );
     let mut output = "async {
     use ::marigold::marigold_impl::*;
     ".to_string();
 
-    let before_streams = expressions
-      .entry(nodes::Placement::BeforeStreams)
-      .or_insert(Vec::new())
+    // Before we can start streaming, we need to declare the helpers:
+    // the enums and structs, and then the stream variable declarations.
+    let enums_and_structs = <>
+      .iter()
+      .filter_map(|expr| match expr {
+        crate::nodes::TypedExpression::UnnamedReturningStream(_) => None,
+        crate::nodes::TypedExpression::UnnamedNonReturningStream(_) => None,
+        crate::nodes::TypedExpression::NamedReturningStream(_) => None,
+        crate::nodes::TypedExpression::NamedNonReturningStream(_) => None,
+        crate::nodes::TypedExpression::StructDeclaration(s) => Some(s.code()),
+        crate::nodes::TypedExpression::EnumDeclaration(e) => Some(e.code()),
+        crate::nodes::TypedExpression::StreamVariable(v) => None,
+        crate::nodes::TypedExpression::StreamVariableFromPriorStreamVariable(v) => None,
+      })
       .join("\n\n");
 
-    output.push_str(&before_streams);
+    output.push_str(&enums_and_structs);
 
-    let returning_stream_vec = expressions
-      .entry(nodes::Placement::ReturningStream)
-      .or_insert(Vec::new());
+    let stream_variable_declarations = <>
+      .iter()
+      .filter_map(|expr| match expr {
+        crate::nodes::TypedExpression::UnnamedReturningStream(_) => None,
+        crate::nodes::TypedExpression::UnnamedNonReturningStream(_) => None,
+        crate::nodes::TypedExpression::NamedReturningStream(_) => None,
+        crate::nodes::TypedExpression::NamedNonReturningStream(_) => None,
+        crate::nodes::TypedExpression::StructDeclaration(s) => None,
+        crate::nodes::TypedExpression::EnumDeclaration(e) => None,
+        crate::nodes::TypedExpression::StreamVariable(v) => Some(v.declaration_code()),
+        crate::nodes::TypedExpression::StreamVariableFromPriorStreamVariable(v) => Some(v.declaration_code()),
+      })
+      .join("\n\n");
+
+    output.push_str(&stream_variable_declarations);
+
+    let returning_stream_vec = <>
+      .iter()
+      .filter_map(
+        |expr| match expr {
+          crate::nodes::TypedExpression::UnnamedReturningStream(s) => Some(s.code()),
+          crate::nodes::TypedExpression::UnnamedNonReturningStream(_) => None,
+          crate::nodes::TypedExpression::NamedReturningStream(s) => Some(s.code()),
+          crate::nodes::TypedExpression::NamedNonReturningStream(_) => None,
+          crate::nodes::TypedExpression::StructDeclaration(_) => None,
+          crate::nodes::TypedExpression::EnumDeclaration(_) => None,
+          crate::nodes::TypedExpression::StreamVariable(_) => None,
+          crate::nodes::TypedExpression::StreamVariableFromPriorStreamVariable(_) => None,
+      })
+      .collect::<Vec<_>>();
 
     let n_returning_streams = returning_stream_vec.len();
+
+    output.push_str(
+      returning_stream_vec
+        .iter()
+        .zip(0..n_returning_streams)
+        .map(|(stream_def, i)| format!("let returning_stream_{i} = Box::pin({stream_def});\n"))
+        .collect::<Vec<_>>()
+        .join("")
+        .as_str()
+    );
+
+    let non_returning_streams = <>
+      .iter()
+      .filter_map(
+        |expr| match expr {
+          crate::nodes::TypedExpression::UnnamedReturningStream(_) => None,
+          crate::nodes::TypedExpression::UnnamedNonReturningStream(s) => Some(s.code()),
+          crate::nodes::TypedExpression::NamedReturningStream(_) => None,
+          crate::nodes::TypedExpression::NamedNonReturningStream(s) => Some(s.code()),
+          crate::nodes::TypedExpression::StructDeclaration(_) => None,
+          crate::nodes::TypedExpression::EnumDeclaration(_) => None,
+          crate::nodes::TypedExpression::StreamVariable(v) => None,
+          crate::nodes::TypedExpression::StreamVariableFromPriorStreamVariable(v) => None,
+      })
+      .collect::<Vec<_>>();
+
+    output.push_str(
+      non_returning_streams
+        .iter()
+        .zip(0..non_returning_streams.len())
+        .map(|(stream_def, i)| format!("let non_returning_stream_{i} = Box::pin({stream_def});\n"))
+        .collect::<Vec<_>>()
+        .join("")
+        .as_str()
+    );
+
+    let stream_variable_runners = <>
+      .iter()
+      .filter_map(
+        |expr| match expr {
+          crate::nodes::TypedExpression::UnnamedReturningStream(_) => None,
+          crate::nodes::TypedExpression::UnnamedNonReturningStream(s) => None,
+          crate::nodes::TypedExpression::NamedReturningStream(_) => None,
+          crate::nodes::TypedExpression::NamedNonReturningStream(s) => None,
+          crate::nodes::TypedExpression::StructDeclaration(_) => None,
+          crate::nodes::TypedExpression::EnumDeclaration(_) => None,
+          crate::nodes::TypedExpression::StreamVariable(v) => Some(v.runner_code()),
+          crate::nodes::TypedExpression::StreamVariableFromPriorStreamVariable(v) => Some(v.runner_code()),
+      })
+      .collect::<Vec<_>>();
+
+    output.push_str(
+      stream_variable_runners
+        .iter()
+        .zip(0..stream_variable_runners.len())
+        .map(|(stream_def, i)| format!("let stream_variable_runners_{i} = Box::pin({stream_def});\n"))
+        .collect::<Vec<_>>()
+        .join("")
+        .as_str()
+    );
 
     let mut streams_string = "vec![\n".to_string();
 
     streams_string.push_str(
-      returning_stream_vec
-        .iter()
-        .map(|stream_def| format!("Box::pin({stream_def}),\n"))
+      (0..n_returning_streams)
+        .map(|i| format!("returning_stream_{i},\n"))
         .collect::<Vec<_>>()
         .join("")
         .as_str()
     );
 
     streams_string.push_str(
-      expressions
-        .entry(nodes::Placement::StreamWithoutSpecificPlacement)
-        .or_insert(Vec::new())
-        .iter()
-        .map(|stream_def| format!("Box::pin({stream_def}),\n"))
+      (0..non_returning_streams.len())
+        .map(|i| format!("non_returning_stream_{i},\n"))
+        .collect::<Vec<_>>()
+        .join("")
+        .as_str()
+    );
+
+    streams_string.push_str(
+      (0..stream_variable_runners.len())
+        .map(|i| format!("stream_variable_runners_{i},\n"))
         .collect::<Vec<_>>()
         .join("")
         .as_str()
@@ -69,7 +153,7 @@ pub Program: String = {
       output.push_str(
         format!("
         /// silly function that uses generics to infer the output type (StreamItem) via generics, so that
-        /// we can provide the streams as an array of Pin<Box<Stream<Item=StreamItem>>>.
+        /// we can provide the streams as an array of Pin<Box<dyn Stream<Item=StreamItem>>>.
         #[inline(always)]
         fn typed_stream_vec<StreamItem>(v: Vec<core::pin::Pin<Box<dyn futures::Stream<Item=StreamItem>>>>) -> Vec<core::pin::Pin<Box<dyn futures::Stream<Item=StreamItem>>>> {{
          v
@@ -78,11 +162,10 @@ pub Program: String = {
       );
       output.push_str(format!("let streams_array = typed_stream_vec({streams_string});").as_str());
     } else {
-      output.push_str(format!("let streams_array:  Vec<core::pin::Pin<Box<dyn futures::Stream<Item=()>>>> = {streams_string};").as_str());
+      output.push_str(format!("let streams_array:  Vec<core::pin::Pin<dyn futures::Stream<Item=()>>> = {streams_string};").as_str());
     }
 
     output.push_str("let mut all_streams = ::marigold::marigold_impl::futures::stream::select_all(streams_array);");
-
 
     if n_returning_streams == 0 {
       output.push_str("all_streams.collect::<Vec<()>>().await;\n");
@@ -96,8 +179,9 @@ pub Program: String = {
   }
 }
 
-Expr: nodes::ExpressionWithPlacement = {
+Expr: nodes::TypedExpression = {
   Stream,
+  StreamVariableDeclaration,
   StructDeclaration,
   EnumDeclaration
 }
@@ -113,22 +197,22 @@ QuotedFreeText: String = {
   <variable_name: r"[0-9A-Za-z/_\-]+"> => variable_name.to_string()
 }
 
-StructDeclaration: nodes::ExpressionWithPlacement = {
-  "struct" <struct_name: FreeText> "{" <field_declarations: (StructFieldDeclaration ",")*> "}" => nodes::ExpressionWithPlacement {
-    placement: nodes::Placement::BeforeStreams,
-    code: crate::nodes::StructDeclarationNode {
-      name: struct_name,
-      fields: {
-        let mut v = Vec::new();
-        for ((field_name, field_value_str), _comma_str) in field_declarations.into_iter() {
-          let field_value = crate::nodes::Type::from_str(field_value_str.as_str())
-            .expect("could not parse type in struct definition");
-          v.push((field_name, field_value));
+StructDeclaration: nodes::TypedExpression = {
+  "struct" <struct_name: FreeText> "{" <field_declarations: (StructFieldDeclaration ",")*> "}" =>
+    nodes::TypedExpression::from(
+      crate::nodes::StructDeclarationNode {
+        name: struct_name,
+        fields: {
+          let mut v = Vec::new();
+          for ((field_name, field_value_str), _comma_str) in field_declarations.into_iter() {
+            let field_value = crate::nodes::Type::from_str(field_value_str.as_str())
+              .expect("could not parse type in struct definition");
+            v.push((field_name, field_value));
+          }
+          v
         }
-        v
       }
-    }.code(),
-  }
+    )
 }
 
 StructFieldDeclaration: (String, String) = {
@@ -137,20 +221,20 @@ StructFieldDeclaration: (String, String) = {
  }
 }
 
-EnumDeclaration: nodes::ExpressionWithPlacement = {
-  "enum" <enum_name: FreeText> "{" <field_declarations: (EnumFieldDeclaration ",")*> "}" => nodes::ExpressionWithPlacement {
-    placement: nodes::Placement::BeforeStreams,
-    code: crate::nodes::EnumDeclarationNode {
-      name: enum_name,
-      fields: field_declarations
-        .into_iter()
-        .map(
-          |((field_name, field_value_str), _comma_str)|
-            (field_name, field_value_str)
-        )
-        .collect::<Vec<(String, Option<String>)>>()
-    }.code(),
-  }
+EnumDeclaration: nodes::TypedExpression = {
+  "enum" <enum_name: FreeText> "{" <field_declarations: (EnumFieldDeclaration ",")*> "}" =>
+    nodes::TypedExpression::from(
+      crate::nodes::EnumDeclarationNode {
+        name: enum_name,
+        fields: field_declarations
+          .into_iter()
+          .map(
+            |((field_name, field_value_str), _comma_str)|
+              (field_name, field_value_str)
+          )
+          .collect::<Vec<(String, Option<String>)>>()
+      }
+    )
 }
 
 EnumFieldDeclaration: (String, Option<String>) = {
@@ -162,19 +246,42 @@ EnumFieldDeclaration: (String, Option<String>) = {
  }
 }
 
-Stream: nodes::ExpressionWithPlacement = {
-  <inp: InputFunction> <funs:("." <StreamFunction>)*> "." <out: OutputFunction> => {
-      let placement = out.placement;
-      let exp = nodes::StreamNode {
+Stream: nodes::TypedExpression = {
+  <inp: InputFunction> <funs:("." <StreamFunction>)*> "." <out: OutputFunction> =>
+    nodes::TypedExpression::from(
+      nodes::UnnamedStreamNode{
         inp,
         funs,
         out
-      };
-      nodes::ExpressionWithPlacement {
-        placement: placement,
-        code: exp.code(),
       }
-    },
+    ),
+  <stream_variable: FreeText> <funs:("." <StreamFunction>)*> "." <out: OutputFunction> =>
+    nodes::TypedExpression::from(
+      nodes::NamedStreamNode {
+        stream_variable,
+        funs,
+        out
+      }
+    )
+}
+
+StreamVariableDeclaration: nodes::TypedExpression = {
+  <field_name: FreeText> "=" <inp: InputFunction> <funs:("." <StreamFunction>)*>  =>
+    nodes::TypedExpression::from(
+      nodes::StreamVariableNode {
+        variable_name: field_name,
+        inp: inp,
+        funs: funs
+      }
+    ),
+  <field_name: FreeText> "=" <stream_variable: FreeText> <funs:("." <StreamFunction>)*>  =>
+    nodes::TypedExpression::from(
+      nodes::StreamVariableFromPriorStreamVariableNode {
+        variable_name: field_name,
+        prior_stream_variable: stream_variable,
+        funs: funs
+      }
+    )
 }
 
 InputFunction: nodes::InputFunctionNode = {
@@ -264,9 +371,9 @@ StreamFunction: nodes::StreamFunctionNode = {
     #[cfg(any(feature = "tokio", feature = "async-std"))]
     return nodes::StreamFunctionNode {
       code: format!("map(|v| async move {{
-        if {filter_fn}(&v) {
+        if {filter_fn}(&v) {{
           Some(v)
-        }
+        }}
         None
       }})
       .buffered(
@@ -301,8 +408,7 @@ StreamFunction: nodes::StreamFunctionNode = {
   "map(" <mapping_fn: FreeText> ")" => {
     #[cfg(any(feature = "tokio", feature = "async-std"))]
     return nodes::StreamFunctionNode {
-      code: format!("map(|v| async move {{{mapping_fn}(v)}})
-      .buffered(std::cmp::max(2 * (::marigold::marigold_impl::num_cpus::get() - 1), 2))"),
+      code: format!("map(|v| async move {{{mapping_fn}(v)}}).buffered(std::cmp::max(2 * (::marigold::marigold_impl::num_cpus::get() - 1), 2))"),
     };
 
     #[cfg(not(any(feature = "tokio", feature = "async-std")))]
@@ -323,7 +429,7 @@ OutputFunction: nodes::OutputFunctionNode = {
   "return" => nodes::OutputFunctionNode {
     stream_prefix: "".to_string(),
     stream_postfix: "".to_string(),
-    placement: nodes::Placement::ReturningStream,
+    returning: true
   },
   "write_file(" <path: QuotedFreeText> "," "csv" ")" => {
     if path.ends_with(".gz\"") {
@@ -409,7 +515,7 @@ OutputFunction: nodes::OutputFunctionNode = {
                 })
             )
         }".to_string(),
-        placement: nodes::Placement::StreamWithoutSpecificPlacement,
+        returning: false
       };
     } else {
       return nodes::OutputFunctionNode {
@@ -488,7 +594,7 @@ OutputFunction: nodes::OutputFunctionNode = {
                   })
               )
           }".to_string(),
-          placement: nodes::Placement::StreamWithoutSpecificPlacement,
+          returning: false
         }
       };
   },
@@ -567,7 +673,7 @@ OutputFunction: nodes::OutputFunctionNode = {
               })
           )
       }".to_string(),
-      placement: nodes::Placement::StreamWithoutSpecificPlacement,
+      returning: false,
     },
     "write_file(" <path: QuotedFreeText> "," "csv" "," "compression" "=" "gz" ")" => nodes::OutputFunctionNode {
       stream_prefix: format!("{{
@@ -651,6 +757,6 @@ OutputFunction: nodes::OutputFunctionNode = {
                 })
             )
         }".to_string(),
-        placement: nodes::Placement::StreamWithoutSpecificPlacement,
+        returning: false,
       }
 }

--- a/marigold-grammar/src/ast.lalrpop
+++ b/marigold-grammar/src/ast.lalrpop
@@ -81,8 +81,8 @@ pub Program: String = {
           crate::nodes::TypedExpression::NamedNonReturningStream(s) => Some(s.code()),
           crate::nodes::TypedExpression::StructDeclaration(_) => None,
           crate::nodes::TypedExpression::EnumDeclaration(_) => None,
-          crate::nodes::TypedExpression::StreamVariable(v) => None,
-          crate::nodes::TypedExpression::StreamVariableFromPriorStreamVariable(v) => None,
+          crate::nodes::TypedExpression::StreamVariable(_) => None,
+          crate::nodes::TypedExpression::StreamVariableFromPriorStreamVariable(_) => None,
       })
       .collect::<Vec<_>>();
 
@@ -101,9 +101,9 @@ pub Program: String = {
       .filter_map(
         |expr| match expr {
           crate::nodes::TypedExpression::UnnamedReturningStream(_) => None,
-          crate::nodes::TypedExpression::UnnamedNonReturningStream(s) => None,
+          crate::nodes::TypedExpression::UnnamedNonReturningStream(_) => None,
           crate::nodes::TypedExpression::NamedReturningStream(_) => None,
-          crate::nodes::TypedExpression::NamedNonReturningStream(s) => None,
+          crate::nodes::TypedExpression::NamedNonReturningStream(_) => None,
           crate::nodes::TypedExpression::StructDeclaration(_) => None,
           crate::nodes::TypedExpression::EnumDeclaration(_) => None,
           crate::nodes::TypedExpression::StreamVariable(v) => Some(v.runner_code()),

--- a/marigold-impl/Cargo.toml
+++ b/marigold-impl/Cargo.toml
@@ -34,6 +34,7 @@ arrayvec = "0.7"
 flate2 = {version="1", optional=true}
 serde = {version="1", optional=true}
 once_cell = "1.13.0"
+pin-utils = "0.1.0"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"]}

--- a/marigold-impl/src/lib.rs
+++ b/marigold-impl/src/lib.rs
@@ -5,6 +5,7 @@ mod async_runtime;
 pub mod collect_and_apply;
 pub mod combinations;
 pub mod keep_first_n;
+pub mod multi_consumer_stream;
 pub mod permutations;
 
 pub use collect_and_apply::CollectAndAppliable;

--- a/marigold-impl/src/multi_consumer_stream.rs
+++ b/marigold-impl/src/multi_consumer_stream.rs
@@ -64,7 +64,7 @@ impl<
                     .collect::<FuturesUnordered<_>>();
                 while let Some(_result) = futures.next().await {}
             }
-            self.senders.iter_mut().for_each(|mut s| s.disconnect());
+            self.senders.iter_mut().for_each(|s| s.disconnect());
         }
     }
 }

--- a/marigold-impl/src/multi_consumer_stream.rs
+++ b/marigold-impl/src/multi_consumer_stream.rs
@@ -1,0 +1,102 @@
+use core::marker::PhantomData;
+use core::pin::Pin;
+use futures::channel::mpsc::Receiver;
+use futures::channel::mpsc::Sender;
+use futures::future::Future;
+use futures::sink::SinkExt;
+use futures::stream::FuturesUnordered;
+use futures::stream::Stream;
+use futures::stream::StreamExt;
+use futures::task::Context;
+use futures::task::Poll;
+
+const BUFFER_SIZE: usize = 1;
+
+pub struct MultiConsumerStream<
+    T: std::marker::Send + 'static,
+    S: Stream<Item = T> + std::marker::Unpin + std::marker::Send + 'static,
+> {
+    inner_stream: S,
+    senders: Vec<Sender<T>>,
+}
+
+impl<
+        T: std::marker::Send + Copy + 'static,
+        S: Stream<Item = T> + std::marker::Unpin + std::marker::Send + 'static,
+    > MultiConsumerStream<T, S>
+{
+    pub fn new(s: S) -> Self {
+        MultiConsumerStream {
+            inner_stream: s,
+            senders: Vec::new(),
+        }
+    }
+
+    pub fn get(&mut self) -> Receiver<T> {
+        let (sender, receiver) = futures::channel::mpsc::channel(BUFFER_SIZE);
+        self.senders.push(sender);
+        receiver
+    }
+
+    pub async fn run(mut self) {
+        self.senders.shrink_to_fit();
+
+        #[cfg(any(feature = "async-std", feature = "tokio"))]
+        crate::async_runtime::spawn(async move {
+            while let Some(v) = self.inner_stream.next().await {
+                let mut futures = self
+                    .senders
+                    .iter_mut()
+                    .map(|sender| sender.feed(v))
+                    .collect::<FuturesUnordered<_>>();
+                while let Some(_result) = futures.next().await {}
+            }
+            self.senders.iter_mut().for_each(|s| s.disconnect());
+        });
+
+        #[cfg(not(any(feature = "async-std", feature = "tokio")))]
+        {
+            while let Some(v) = self.inner_stream.next().await {
+                let mut futures = self
+                    .senders
+                    .iter_mut()
+                    .map(|sender| sender.feed(v))
+                    .collect::<FuturesUnordered<_>>();
+                while let Some(_result) = futures.next().await {}
+            }
+            self.senders.iter_mut().for_each(|mut s| s.disconnect());
+        }
+    }
+}
+
+pub struct RunFutureAsStream<T: Unpin, O, F: Future<Output = O>> {
+    future: Pin<Box<F>>,
+    t: PhantomData<T>,
+}
+
+impl<T: Unpin, O, F: Future<Output = O>> RunFutureAsStream<T, O, F> {
+    pub fn new(f: Pin<Box<F>>) -> RunFutureAsStream<T, O, F> {
+        RunFutureAsStream {
+            future: f,
+            t: PhantomData,
+        }
+    }
+}
+
+impl<T: std::marker::Send + Unpin + 'static, O, F: Future<Output = O>> Stream
+    for RunFutureAsStream<T, O, F>
+{
+    type Item = T;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let future = &mut self.future;
+        match Pin::new(future).poll(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(_) => Poll::Ready(None),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, None)
+    }
+}


### PR DESCRIPTION
- Refactor so that the program has access to its component expressions as objects, instead of just receiving the code strings. This lets expressions describe fragments of code that can be placed in multiple, non-sequential locations, which is necessary for multi-consumer streams.
- Implement multi-consumer streams.
- Add example / test.

Note: It's not great in terms of performance that we have to wrap each of the streams in a `Pin<Box<_>>`. Since the streams need to be pinned and are returned by the function that generates them, we need some way of pinning them, and can't just `pin_mut!` them to the stack (`rustc --explain E0515`). I haven't seen a viable alternative yet in other codebases.