### PR TITLE
fix(docs): correct cargo install path for workspace repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Or from source:
 
 ```sh
 git clone https://github.com/DominicBurkart/marigold.git
-cd marigold/marigold
-cargo install --path . -F cli
+cd marigold
+cargo install --path marigold -F cli
 ```
 
 ### Hello World

--- a/marigold/README.md
+++ b/marigold/README.md
@@ -50,8 +50,8 @@ Or from source:
 
 ```sh
 git clone https://github.com/DominicBurkart/marigold.git
-cd marigold/marigold
-cargo install --path . -F cli
+cd marigold
+cargo install --path marigold -F cli
 ```
 
 ### Hello World


### PR DESCRIPTION
## Summary
- `cargo install --path . -F cli` fails at the repo root because the root `Cargo.toml` is a workspace manifest
- Fix: change `cd marigold/marigold` + `--path .` to `cd marigold` + `--path marigold`