### PR TITLE
feat(tests): add integration tests for map stream function (#102)

### DIFF
--- a/marigold-grammar/tests/e2e_cardinality.rs
+++ b/marigold-grammar/tests/e2e_cardinality.rs
@@ -84,6 +84,24 @@ mod exact {
     }
 }
 
+mod exact_map {
+    use super::*;
+
+    #[test]
+    fn map_preserves_cardinality() {
+        let result = analyze_file("tests/programs/card_map.marigold");
+        assert_eq!(
+            result.streams[0].cardinality,
+            Cardinality::Exact(BigUint::from(10u64)),
+            "map should preserve exact cardinality from input"
+        );
+        assert_eq!(
+            result.program_cardinality,
+            Cardinality::Exact(BigUint::from(10u64))
+        );
+    }
+}
+
 mod bounded {
     use super::*;
 

--- a/marigold-grammar/tests/e2e_complexity.rs
+++ b/marigold-grammar/tests/e2e_complexity.rs
@@ -141,3 +141,44 @@ fn chained_maps() {
         ExactComplexity::from_str("O(2n)").unwrap()
     );
 }
+
+#[test]
+fn map_reports_o1_space() {
+    let result = analyze_file("tests/programs/map_space.marigold");
+    assert_eq!(result.streams.len(), 1);
+    assert_eq!(
+        result.streams[0].space_class,
+        ComplexityClass::O1,
+        "map should report O(1) space"
+    );
+    assert_eq!(
+        result.streams[0].exact_space,
+        ExactComplexity::from_str("O(1)").unwrap(),
+        "map should report exact space O(1)"
+    );
+    assert!(
+        !result.streams[0].collects_input,
+        "map should not collect input"
+    );
+}
+
+#[test]
+fn map_write_file_reports_o1_space() {
+    let result = analyze_file("tests/programs/map_write_file.marigold");
+    assert_eq!(result.streams.len(), 1);
+    assert_eq!(
+        result.streams[0].space_class,
+        ComplexityClass::O1,
+        "map with write_file should report O(1) space"
+    );
+    assert_eq!(
+        result.streams[0].exact_space,
+        ExactComplexity::from_str("O(1)").unwrap(),
+        "map with write_file should report exact space O(1)"
+    );
+    assert_eq!(
+        result.program_cardinality,
+        Cardinality::Exact(BigUint::from(3u64)),
+        "range(1, 4).map(double) should have cardinality 3"
+    );
+}

--- a/marigold-grammar/tests/programs/card_map.marigold
+++ b/marigold-grammar/tests/programs/card_map.marigold
@@ -1,0 +1,1 @@
+range(0, 10).map(double).return

--- a/marigold-grammar/tests/programs/map_space.marigold
+++ b/marigold-grammar/tests/programs/map_space.marigold
@@ -1,0 +1,1 @@
+range(0, 50).map(transform).return

--- a/marigold-grammar/tests/programs/map_write_file.marigold
+++ b/marigold-grammar/tests/programs/map_write_file.marigold
@@ -1,0 +1,5 @@
+fn double(i: i32) -> i32 {
+  i * 2
+}
+
+range(1, 4).map(double).write_file("/dev/stdout", csv)

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -21,6 +21,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn map_with_named_function() {
+        fn double(i: i32) -> i32 {
+            i * 2
+        }
+
+        let r = m!(
+            range(1, 4)
+                .map(double)
+                .return
+        )
+        .await
+        .collect::<Vec<_>>()
+        .await;
+        assert_eq!(r, vec![2, 4, 6]);
+    }
+
+    #[tokio::test]
     async fn chained_permutations_and_combinations() {
         let r = m!(
             range(0, 2)


### PR DESCRIPTION
## Summary

- Add e2e cardinality test verifying `map` preserves exact cardinality (`range(0, 10).map(double)` → cardinality 10)
- Add e2e complexity tests verifying `map` reports `space_class: O(1)` and `exact_space: O(1)`, both standalone and with `write_file`
- Add integration test for `map` with named function matching issue spec (`range(1, 4).map(double)` → `[2, 4, 6]`)
- Add 3 test program files: `card_map.marigold`, `map_space.marigold`, `map_write_file.marigold`

Closes #102

## Test plan

- [x] `cargo test --all-features` passes locally (all 350+ tests)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-features -- -D warnings` passes
- [ ] CI passes on push

https://claude.ai/code/session_01VuxFrDaFowL4gNdBt3hQnK