### PR TITLE
feat: implement `take` stream function

### DIFF
--- a/marigold-grammar/src/complexity.rs
+++ b/marigold-grammar/src/complexity.rs
@@ -820,7 +820,7 @@ fn propagate_cardinality(cardinality: Symbolic, kind: &StreamFunctionKind) -> Sy
             n: Box::new(cardinality),
             k: *k,
         },
-        StreamFunctionKind::KeepFirstN(k) => Symbolic::Min(
+        StreamFunctionKind::KeepFirstN(k) | StreamFunctionKind::Take(k) => Symbolic::Min(
             Box::new(cardinality),
             Box::new(Symbolic::Constant(BigUint::from(*k))),
         ),
@@ -834,7 +834,7 @@ fn space_for_kind(kind: &StreamFunctionKind) -> ComplexityClass {
         StreamFunctionKind::Permutations(_)
         | StreamFunctionKind::PermutationsWithReplacement(_)
         | StreamFunctionKind::Combinations(_) => ComplexityClass::ON,
-        StreamFunctionKind::KeepFirstN(_) => ComplexityClass::O1,
+        StreamFunctionKind::KeepFirstN(_) | StreamFunctionKind::Take(_) => ComplexityClass::O1,
         StreamFunctionKind::Map
         | StreamFunctionKind::Filter
         | StreamFunctionKind::FilterMap
@@ -936,6 +936,7 @@ fn describe_stream_fns(funs: &[crate::nodes::StreamFunctionNode]) -> String {
             }
             StreamFunctionKind::Combinations(k) => format!("combinations({k})"),
             StreamFunctionKind::KeepFirstN(k) => format!("keep_first_n({k}, ...)"),
+            StreamFunctionKind::Take(k) => format!("take({k})"),
             StreamFunctionKind::Fold => "fold(...)".to_string(),
             StreamFunctionKind::Ok => "ok()".to_string(),
             StreamFunctionKind::OkOrPanic => "ok_or_panic()".to_string(),
@@ -1313,6 +1314,22 @@ mod tests {
     }
 
     #[test]
+    fn test_take_cardinality() {
+        let card = Symbolic::Constant(BigUint::from(100u64));
+        let result = propagate_cardinality(card, &StreamFunctionKind::Take(5));
+        assert!(matches!(result, Symbolic::Min(_, _)));
+        assert_eq!(result.try_evaluate(), Some(BigUint::from(5u64)));
+    }
+
+    #[test]
+    fn test_take_exceeds_cardinality() {
+        let card = Symbolic::Constant(BigUint::from(5u64));
+        let result = propagate_cardinality(card, &StreamFunctionKind::Take(10));
+        assert!(matches!(result, Symbolic::Min(_, _)));
+        assert_eq!(result.try_evaluate(), Some(BigUint::from(5u64)));
+    }
+
+    #[test]
     fn test_chained_filters() {
         let card = Symbolic::Constant(BigUint::from(100u64));
         let r1 = propagate_cardinality(card, &StreamFunctionKind::Filter);
@@ -1365,6 +1382,14 @@ mod tests {
     fn test_keep_first_n_space_o1() {
         assert_eq!(
             space_for_kind(&StreamFunctionKind::KeepFirstN(5)),
+            ComplexityClass::O1
+        );
+    }
+
+    #[test]
+    fn test_take_space_o1() {
+        assert_eq!(
+            space_for_kind(&StreamFunctionKind::Take(5)),
             ComplexityClass::O1
         );
     }
@@ -1476,6 +1501,14 @@ mod tests {
                 .unwrap();
         assert_eq!(result.streams.len(), 1);
         assert_eq!(result.streams[0].space_class, ComplexityClass::O1);
+    }
+
+    #[test]
+    fn test_analyze_take_pipeline() {
+        let result = crate::parser::PestParser::analyze("range(0, 100).take(5).return").unwrap();
+        assert_eq!(result.streams.len(), 1);
+        assert_eq!(result.streams[0].space_class, ComplexityClass::O1);
+        assert!(!result.streams[0].collects_input);
     }
 
     #[test]

--- a/marigold-grammar/src/marigold.pest
+++ b/marigold-grammar/src/marigold.pest
@@ -340,7 +340,7 @@ input_and_maybe_stream_functions = {
 //
 // # Categories
 //
-// **Filtering**: filter, filter_map, keep_first_n
+// **Filtering**: filter, filter_map, keep_first_n, take
 // **Mapping**: map
 // **Combinatorics**: permutations, permutations_with_replacement, combinations
 // **Folding**: fold
@@ -363,6 +363,7 @@ stream_function = {
     permutations_with_replacement_fn |
     combinations_fn |
     keep_first_n_fn |
+    take_fn |
     filter_fn |
     filter_map_fn |
     map_fn |
@@ -403,6 +404,11 @@ combinations_fn = { "combinations(" ~ free_text_literal ~ ")" }
 // Argument 1: stream variable name
 // Argument 2: n (usize) - number of items to keep
 keep_first_n_fn = { "keep_first_n(" ~ free_text_literal ~ "," ~ free_text_identifier ~ ")" }
+
+// take(n) - Limit stream to first n items
+// Transforms Stream<T> -> Stream<T>, yielding at most n items
+// Argument: n (usize) - maximum number of items to yield
+take_fn = { "take(" ~ free_text_literal ~ ")" }
 
 // fold(init, closure) - Reduce stream to single value
 // Transforms Stream<T> -> Stream<Acc> where Acc = closure(Acc, T)

--- a/marigold-grammar/src/nodes.rs
+++ b/marigold-grammar/src/nodes.rs
@@ -261,6 +261,7 @@ pub enum StreamFunctionKind {
     PermutationsWithReplacement(u64),
     Combinations(u64),
     KeepFirstN(u64),
+    Take(u64),
     Fold,
     Ok,
     OkOrPanic,

--- a/marigold-grammar/src/pest_ast_builder.rs
+++ b/marigold-grammar/src/pest_ast_builder.rs
@@ -922,6 +922,10 @@ impl PestAstBuilder {
                     Self::build_keep_first_n_fn(inner)?,
                 )
             }
+            Rule::take_fn => {
+                let n = Self::peek_numeric_arg(&inner)?;
+                (StreamFunctionKind::Take(n), Self::build_take_fn(inner)?)
+            }
             Rule::fold_fn => (StreamFunctionKind::Fold, Self::build_fold_fn(inner)?),
             Rule::ok_fn => (
                 StreamFunctionKind::Ok,
@@ -1029,6 +1033,15 @@ impl PestAstBuilder {
             .ok_or_else(|| "Missing keep_first_n value function".to_string())?
             .as_str();
         Ok(format!("keep_first_n({n}, {value_fn}).await"))
+    }
+
+    fn build_take_fn(pair: Pair<Rule>) -> Result<String, String> {
+        let n = pair
+            .into_inner()
+            .next()
+            .ok_or_else(|| "Missing take count".to_string())?
+            .as_str();
+        Ok(format!("take({n} as usize)"))
     }
 
     fn build_fold_fn(pair: Pair<Rule>) -> Result<String, String> {

--- a/marigold-grammar/tests/e2e_cardinality.rs
+++ b/marigold-grammar/tests/e2e_cardinality.rs
@@ -91,6 +91,24 @@ mod exact {
             Cardinality::Exact(BigUint::from(5u64))
         );
     }
+
+    #[test]
+    fn take() {
+        let result = analyze_file("tests/programs/card_take.marigold");
+        assert_eq!(
+            result.streams[0].cardinality,
+            Cardinality::Exact(BigUint::from(5u64))
+        );
+    }
+
+    #[test]
+    fn take_exceeds() {
+        let result = analyze_file("tests/programs/card_take_exceeds.marigold");
+        assert_eq!(
+            result.streams[0].cardinality,
+            Cardinality::Exact(BigUint::from(5u64))
+        );
+    }
 }
 
 mod bounded {

--- a/marigold-grammar/tests/programs/card_take.marigold
+++ b/marigold-grammar/tests/programs/card_take.marigold
@@ -1,0 +1,1 @@
+range(0, 100).take(5).return

--- a/marigold-grammar/tests/programs/card_take_exceeds.marigold
+++ b/marigold-grammar/tests/programs/card_take_exceeds.marigold
@@ -1,0 +1,1 @@
+range(0, 5).take(10).return

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -218,4 +218,30 @@ mod tests {
         .await;
         assert_eq!(result, vec![0, 1, 2, 3]);
     }
+
+    #[tokio::test]
+    async fn test_take() {
+        let result = m!(
+            range(0, 10)
+                .take(3)
+                .return
+        )
+        .await
+        .collect::<Vec<_>>()
+        .await;
+        assert_eq!(result, vec![0, 1, 2]);
+    }
+
+    #[tokio::test]
+    async fn test_take_exceeds_input() {
+        let result = m!(
+            range(0, 3)
+                .take(10)
+                .return
+        )
+        .await
+        .collect::<Vec<_>>()
+        .await;
+        assert_eq!(result, vec![0, 1, 2]);
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `take(n)` stream function to limit output to the first n elements
- Grammar, codegen, static analysis, and tests included
- `take(n)` maps directly to `futures::StreamExt::take(n)` — no new runtime module needed

## Changes (8 files)
- **Grammar** (`marigold.pest`): `take_fn` rule + added to `stream_function` alternatives
- **AST** (`nodes.rs`): `StreamFunctionKind::Take(u64)` variant
- **Builder** (`pest_ast_builder.rs`): `Rule::take_fn` arm + `build_take_fn()`
- **Analysis** (`complexity.rs`): Cardinality = min(input, n), O(1) space, 4 unit tests
- **E2E tests** (`e2e_cardinality.rs`): `take` and `take_exceeds` cardinality tests
- **Integration tests** (`tests/src/lib.rs`): `test_take` and `test_take_exceeds_input`
- **Test programs**: `card_take.marigold`, `card_take_exceeds.marigold`

## Test plan
- [x] `cargo test -p marigold-grammar` — 306 passed
- [x] `cargo test -p tests` — 12 passed
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

## Known gaps (can address in follow-up)
- CLI integration tests for `marigold run` / `marigold analyze` with take
- `filter_then_take` bounded cardinality test
- Negative integer range test (`range(-10, 10).take(2)`)
- Proptest generator for take in `proptest_analyze.rs`

Closes #85

https://claude.ai/code/session_0159oFdiMYFYqMCR4t9QEejB