### PR TITLE
[marigold] [Testing]: Expand unit and integration test coverage

### DIFF
--- a/marigold-grammar/src/nodes.rs
+++ b/marigold-grammar/src/nodes.rs
@@ -272,7 +272,7 @@ pub struct StreamFunctionNode {
 }
 
 /// Number of inputs
-#[derive(PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub enum InputCount {
     Known(num_bigint::BigUint),
     /// Variant count for `range(EnumName)` — resolved to `Known` after symbol table lookup.
@@ -282,7 +282,7 @@ pub enum InputCount {
 
 /// Whether the input is known at compile time (constant),
 /// or whether it is not available until runtime (variable).
-#[derive(PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub enum InputVariability {
     Constant,
     Variable,

--- a/marigold-grammar/src/type_aggregation.rs
+++ b/marigold-grammar/src/type_aggregation.rs
@@ -26,3 +26,73 @@ pub fn aggregate_input_count<I: IntoIterator<Item = nodes::InputCount>>(
     }
     nodes::InputCount::Known(total_count)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nodes::{InputCount, InputVariability};
+    use num_bigint::BigUint;
+
+    // --- aggregate_input_variability ---
+
+    #[test]
+    fn variability_all_constant_is_constant() {
+        let result = aggregate_input_variability(vec![
+            InputVariability::Constant,
+            InputVariability::Constant,
+        ]);
+        assert_eq!(result, InputVariability::Constant);
+    }
+
+    #[test]
+    fn variability_any_variable_is_variable() {
+        let result = aggregate_input_variability(vec![
+            InputVariability::Constant,
+            InputVariability::Variable,
+            InputVariability::Constant,
+        ]);
+        assert_eq!(result, InputVariability::Variable);
+    }
+
+    #[test]
+    fn variability_empty_is_constant() {
+        let result = aggregate_input_variability(vec![]);
+        assert_eq!(result, InputVariability::Constant);
+    }
+
+    // --- aggregate_input_count ---
+
+    #[test]
+    fn count_known_values_are_summed() {
+        let result = aggregate_input_count(vec![
+            InputCount::Known(BigUint::from(3u32)),
+            InputCount::Known(BigUint::from(7u32)),
+        ]);
+        assert_eq!(result, InputCount::Known(BigUint::from(10u32)));
+    }
+
+    #[test]
+    fn count_empty_sums_to_zero() {
+        let result = aggregate_input_count(vec![]);
+        assert_eq!(result, InputCount::Known(BigUint::from(0u32)));
+    }
+
+    #[test]
+    fn count_unknown_short_circuits() {
+        let result = aggregate_input_count(vec![
+            InputCount::Known(BigUint::from(5u32)),
+            InputCount::Unknown,
+            InputCount::Known(BigUint::from(3u32)),
+        ]);
+        assert_eq!(result, InputCount::Unknown);
+    }
+
+    #[test]
+    fn count_enum_placeholder_short_circuits() {
+        let result = aggregate_input_count(vec![
+            InputCount::Known(BigUint::from(5u32)),
+            InputCount::Enum("Color".to_string()),
+        ]);
+        assert_eq!(result, InputCount::Unknown);
+    }
+}

--- a/marigold-impl/src/collect_and_apply.rs
+++ b/marigold-impl/src/collect_and_apply.rs
@@ -31,7 +31,7 @@ mod tests {
     use super::CollectAndAppliable;
 
     #[tokio::test]
-    async fn collect_and_apply() {
+    async fn collect_and_apply_identity() {
         assert_eq!(
             futures::stream::iter(1..=3).collect_and_apply(|x| x).await,
             vec![1, 2, 3]
@@ -39,7 +39,25 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn permutations_with_replacement() {
+    async fn collect_and_apply_empty_stream() {
+        let result: Vec<i32> = futures::stream::iter(std::iter::empty::<i32>())
+            .collect_and_apply(|x| x)
+            .await;
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn collect_and_apply_transformation() {
+        // Verify the function receives the fully-collected vector, not a stream.
+        let sum = futures::stream::iter(1..=5i32)
+            .collect_and_apply(|v| v.into_iter().sum::<i32>())
+            .await;
+        assert_eq!(sum, 15);
+    }
+
+    /// Demonstrates that collect_and_apply can return a future (e.g., for lazy generators).
+    #[tokio::test]
+    async fn collect_and_apply_returns_async_generator() {
         use futures::StreamExt;
         use genawaiter;
 

--- a/marigold-impl/src/combinations.rs
+++ b/marigold-impl/src/combinations.rs
@@ -38,7 +38,7 @@ mod tests {
     use futures::stream::StreamExt;
 
     #[tokio::test]
-    async fn combinations() {
+    async fn combinations_k2_from_3() {
         assert_eq!(
             futures::stream::iter(vec![1, 2, 3])
                 .combinations(2)
@@ -47,5 +47,35 @@ mod tests {
                 .await,
             vec![vec![1, 2], vec![1, 3], vec![2, 3],]
         );
+    }
+
+    #[tokio::test]
+    async fn combinations_k_equals_n_yields_one_result() {
+        let result = futures::stream::iter(vec![1, 2, 3])
+            .combinations(3)
+            .await
+            .collect::<Vec<_>>()
+            .await;
+        assert_eq!(result, vec![vec![1, 2, 3]]);
+    }
+
+    #[tokio::test]
+    async fn combinations_k_greater_than_n_yields_nothing() {
+        let result = futures::stream::iter(vec![1, 2])
+            .combinations(5)
+            .await
+            .collect::<Vec<_>>()
+            .await;
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn combinations_k0_yields_one_empty_vec() {
+        let result = futures::stream::iter(vec![1, 2, 3])
+            .combinations(0)
+            .await
+            .collect::<Vec<_>>()
+            .await;
+        assert_eq!(result, vec![vec![]]);
     }
 }

--- a/marigold-impl/src/multi_consumer_stream.rs
+++ b/marigold-impl/src/multi_consumer_stream.rs
@@ -100,3 +100,60 @@ impl<T: std::marker::Send + Unpin + 'static, O, F: Future<Output = O>> Stream
         (0, None)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream::StreamExt;
+
+    /// A single consumer receives all items from the inner stream.
+    #[tokio::test]
+    async fn single_consumer_receives_all_items() {
+        let mut mcs = MultiConsumerStream::new(futures::stream::iter(vec![1u32, 2, 3]));
+        let receiver = mcs.get();
+        mcs.run().await;
+        let items: Vec<u32> = receiver.collect().await;
+        assert_eq!(items, vec![1, 2, 3]);
+    }
+
+    /// Two consumers each receive every item (broadcast semantics).
+    #[tokio::test]
+    async fn two_consumers_both_receive_all_items() {
+        let mut mcs = MultiConsumerStream::new(futures::stream::iter(vec![10u32, 20, 30]));
+        let r1 = mcs.get();
+        let r2 = mcs.get();
+        mcs.run().await;
+
+        let (items1, items2): (Vec<u32>, Vec<u32>) =
+            futures::future::join(r1.collect(), r2.collect()).await;
+        assert_eq!(items1, vec![10, 20, 30]);
+        assert_eq!(items2, vec![10, 20, 30]);
+    }
+
+    /// An empty inner stream terminates all consumers immediately.
+    #[tokio::test]
+    async fn empty_stream_terminates_consumers() {
+        let mut mcs = MultiConsumerStream::new(futures::stream::iter(std::iter::empty::<u32>()));
+        let receiver = mcs.get();
+        mcs.run().await;
+        let items: Vec<u32> = receiver.collect().await;
+        assert!(items.is_empty());
+    }
+
+    /// RunFutureAsStream produces no items and terminates after the future completes.
+    #[tokio::test]
+    async fn run_future_as_stream_yields_no_items() {
+        let fut = Box::pin(async { () });
+        let stream: RunFutureAsStream<u32, (), _> = RunFutureAsStream::new(fut);
+        let items: Vec<u32> = stream.collect().await;
+        assert!(items.is_empty());
+    }
+
+    /// RunFutureAsStream reports size_hint of (0, None).
+    #[test]
+    fn run_future_as_stream_size_hint() {
+        let fut = Box::pin(async { () });
+        let stream: RunFutureAsStream<u32, (), _> = RunFutureAsStream::new(fut);
+        assert_eq!(stream.size_hint(), (0, None));
+    }
+}

--- a/marigold-impl/src/permutations.rs
+++ b/marigold-impl/src/permutations.rs
@@ -57,7 +57,7 @@ mod tests {
     use futures::stream::StreamExt;
 
     #[tokio::test]
-    async fn permutations() {
+    async fn permutations_k2_from_3() {
         assert_eq!(
             futures::stream::iter(vec![1, 2, 3])
                 .permutations(2)
@@ -76,7 +76,28 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn permutations_with_replacement() {
+    async fn permutations_k_equals_n_yields_all_orderings() {
+        let mut result = futures::stream::iter(vec![1, 2])
+            .permutations(2)
+            .await
+            .collect::<Vec<_>>()
+            .await;
+        result.sort();
+        assert_eq!(result, vec![vec![1, 2], vec![2, 1]]);
+    }
+
+    #[tokio::test]
+    async fn permutations_k0_yields_one_empty_vec() {
+        let result = futures::stream::iter(vec![1, 2, 3])
+            .permutations(0)
+            .await
+            .collect::<Vec<_>>()
+            .await;
+        assert_eq!(result, vec![vec![]]);
+    }
+
+    #[tokio::test]
+    async fn permutations_with_replacement_k2_from_3() {
         assert_eq!(
             futures::stream::iter(vec![0, 1, 2])
                 .permutations_with_replacement(2)
@@ -95,5 +116,16 @@ mod tests {
                 vec![2, 2],
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn permutations_with_replacement_count() {
+        // n=3, k=3 → 3^3 = 27 results
+        let result = futures::stream::iter(vec![0u32, 1, 2])
+            .permutations_with_replacement(3)
+            .await
+            .collect::<Vec<_>>()
+            .await;
+        assert_eq!(result.len(), 27);
     }
 }

--- a/marigold-impl/src/run_stream.rs
+++ b/marigold-impl/src/run_stream.rs
@@ -40,12 +40,30 @@ mod tests {
     use futures::stream::StreamExt;
 
     #[tokio::test]
-    async fn combinations() {
+    async fn run_stream_preserves_items() {
         assert_eq!(
             run_stream(futures::stream::iter(0_u32..3_u32))
                 .collect::<Vec<_>>()
                 .await,
             vec![0_u32, 1_u32, 2_u32]
+        );
+    }
+
+    #[tokio::test]
+    async fn run_stream_empty() {
+        let result = run_stream(futures::stream::iter(std::iter::empty::<u32>()))
+            .collect::<Vec<_>>()
+            .await;
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn run_stream_single_item() {
+        assert_eq!(
+            run_stream(futures::stream::iter(std::iter::once(42_u32)))
+                .collect::<Vec<_>>()
+                .await,
+            vec![42_u32]
         );
     }
 }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -218,4 +218,70 @@ mod tests {
         .await;
         assert_eq!(result, vec![0, 1, 2, 3]);
     }
+
+    /// fold accumulates the stream using a named function.
+    #[tokio::test]
+    async fn test_fold_sum() {
+        fn add(acc: i32, x: i32) -> i32 {
+            acc + x
+        }
+
+        let result: Vec<i32> = m!(
+            range(1, =5)
+                .fold(0, add)
+                .return
+        )
+        .await
+        .collect::<Vec<_>>()
+        .await;
+        assert_eq!(result, vec![15]);
+    }
+
+    /// fold on an empty range emits the initial accumulator unchanged.
+    #[tokio::test]
+    async fn test_fold_empty_range() {
+        fn identity(acc: i32, _x: i32) -> i32 {
+            acc
+        }
+
+        let result: Vec<i32> = m!(
+            range(0, 0)
+                .fold(42, identity)
+                .return
+        )
+        .await
+        .collect::<Vec<_>>()
+        .await;
+        assert_eq!(result, vec![42]);
+    }
+
+    /// keep_first_n returns the N largest values (descending) using a named comparator.
+    #[tokio::test]
+    async fn test_keep_first_n_top3() {
+        fn by_value(a: &i32, b: &i32) -> std::cmp::Ordering {
+            a.cmp(b)
+        }
+
+        let result: Vec<i32> = m!(
+            range(0, 10)
+                .keep_first_n(3, by_value)
+                .return
+        )
+        .await
+        .collect::<Vec<_>>()
+        .await;
+        assert_eq!(result, vec![9, 8, 7]);
+    }
+
+    /// range with n == 1 yields exactly one element.
+    #[tokio::test]
+    async fn test_single_element_range() {
+        let result: Vec<i32> = m!(
+            range(5, 6).return
+        )
+        .await
+        .collect::<Vec<_>>()
+        .await;
+        assert_eq!(result, vec![5]);
+    }
 }


### PR DESCRIPTION
## Summary

This PR adds targeted tests to components that had no coverage or only a single happy-path test.

**marigold-impl new/improved tests:**

- `multi_consumer_stream`: Previously zero tests. Added: single consumer receives all items, two-consumer broadcast (both get every item), empty stream terminates consumers, `RunFutureAsStream` yields no items and reports correct `size_hint`.

- `run_stream`: The single existing test was named `combinations` (wrong). Renamed to `run_stream_preserves_items` and added empty-stream and single-item cases.

- `collect_and_apply`: Renamed `permutations_with_replacement` (misleading name for a test that had nothing to do with permutations) to `collect_and_apply_returns_async_generator`. Added empty-stream and sum-transformation cases.

- `combinations`: Added k==n, k>n (yields nothing), and k==0 (yields one empty vec) edge cases.

- `permutations`: Added k==n, k==0 edge cases and a count assertion for `permutations_with_replacement(3)` (3³=27).

**marigold-grammar:**

- `type_aggregation`: Was entirely untested. Added complete test suite for both `aggregate_input_variability` (all-constant, any-variable, empty) and `aggregate_input_count` (sum, empty→zero, Unknown short-circuit, Enum short-circuit).

- `nodes`: Added `Debug` derives to `InputCount` and `InputVariability` so they work in `assert_eq!`.

**Integration tests (`tests/src/lib.rs`):**

- `test_fold_sum`: fold/marifold accumulates to correct sum (1..=5 → 15)
- `test_fold_empty_range`: fold on empty range emits the initial accumulator unchanged
- `test_keep_first_n_top3`: keep_first_n returns top 3 in descending order
- `test_single_element_range`: range with n==1 yields exactly one element

## Test plan

- [ ] `cargo test -p marigold-impl --features tokio` — all 31 tests pass
- [ ] `cargo test -p marigold-grammar` — all grammar tests pass
- [ ] `cargo test -p tests` — all 14 integration tests pass

https://claude.ai/code/session_015qvaT243enNQXYo7QXJudF