### PR TITLE
[marigold] [Clarity]: Fix stale/misleading comments, trim verbose docs, remove dead commented code

### DIFF
--- a/marigold-grammar/src/lib.rs
+++ b/marigold-grammar/src/lib.rs
@@ -1,66 +1,23 @@
 #![forbid(unsafe_code)]
 
-//! # Marigold Grammar Library
+//! Grammar, parser, and code-generation for the Marigold DSL.
 //!
-//! This crate provides the grammar and parser infrastructure for the Marigold DSL.
+//! The main entry point is [`marigold_parse`], which takes a Marigold program string and
+//! returns generated Rust code. [`marigold_analyze`] returns static complexity information
+//! without generating code.
 //!
-//! ## Overview
+//! ## Module overview
 //!
-//! Marigold is a domain-specific language for expressing stream processing programs in Rust.
-//! This library provides:
+//! | Module | Purpose |
+//! |--------|---------|
+//! | [`parser`] | Pest-based PEG parser and `MarigoldParser` trait |
+//! | [`nodes`] | AST node types for all Marigold constructs |
+//! | [`pest_ast_builder`] | Converts Pest parse trees into AST nodes |
+//! | [`complexity`] | Static complexity analysis (time/space/cardinality) |
+//! | [`bound_resolution`] | Resolves symbolic bounds in bounded-integer types |
+//! | [`symbol_table`] | Tracks declared enums and struct fields for bound resolution |
 //!
-//! - **Pest-based parser**: Fast, maintainable PEG parser
-//! - **AST definitions**: Complete abstract syntax tree for Marigold programs
-//! - **Code generation**: Transforms Marigold programs into valid Rust code
-//!
-//! ## Quick Start
-//!
-//! Parse a Marigold program:
-//!
-//! ```ignore
-//! use marigold_grammar::parser::parse_marigold;
-//!
-//! let code = parse_marigold("range(0, 100).return")?;
-//! println!("{}", code);
-//! ```
-//!
-//! ## Architecture
-//!
-//! ### Parser
-//!
-//! The [`parser`] module provides the Pest-based parser with a trait abstraction
-//! for extensibility. The factory function [`parser::get_parser()`] returns a
-//! parser instance.
-//!
-//! ### Grammar File
-//!
-//! - **Pest**: `src/marigold.pest` - Defines the complete Marigold language grammar
-//!
-//! ### AST and Code Generation
-//!
-//! - [`nodes`]: AST node definitions for all Marigold constructs
-//! - Code generation: Internal function that transforms AST to Rust code
-//! - [`pest_ast_builder`]: Transforms Pest parse trees into the AST
-//!
-//! ## Testing & Validation
-//!
-//! The parser implementation is validated through:
-//!
-//! - **Unit tests** in each module covering specific functionality
-//! - **Negative tests** ensuring invalid syntax is properly rejected
-//! - **Integration tests** using real-world example programs
-//!
-//! ## Feature Flags
-//!
-//! - `io`: I/O features (available in other crates)
-//! - `tokio`: Tokio runtime integration (available in other crates)
-//! - `async-std`: async-std runtime integration (available in other crates)
-//!
-//! ## Performance Characteristics
-//!
-//! - **Parsing**: Completes in < 1ms for typical programs
-//! - **Code generation**: Dominates runtime, scales with program complexity
-//! - **Binary size**: Pest parser adds ~40KB to binary size
+//! The grammar itself lives in `src/marigold.pest`.
 
 #[macro_use]
 extern crate lazy_static;
@@ -78,23 +35,17 @@ mod type_aggregation;
 
 pub mod pest_ast_builder;
 
-/// Convenience function for parsing Marigold code
-///
-/// This is an alias for [`parser::parse_marigold`] that uses the appropriate parser
-/// based on feature flags. It's the recommended entry point for most use cases.
-///
-/// # Examples
+/// Parse a Marigold program and return the generated Rust code.
 ///
 /// ```ignore
-/// use marigold_grammar::marigold_parse;
-///
-/// let code = marigold_parse("range(0, 100).return")?;
-/// // code is now valid Rust code ready to compile
+/// let code = marigold_grammar::marigold_parse("range(0, 100).return")?;
+/// // code is async Rust ready to compile
 /// ```
 pub fn marigold_parse(s: &str) -> Result<String, parser::MarigoldParseError> {
     parser::parse_marigold(s)
 }
 
+/// Parse a Marigold program and return its static complexity analysis without generating code.
 pub fn marigold_analyze(
     s: &str,
 ) -> Result<complexity::ProgramComplexity, parser::MarigoldParseError> {
@@ -104,8 +55,8 @@ pub fn marigold_analyze(
 #[cfg(test)]
 mod tests {
     #[test]
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 4);
+    fn parse_returns_async_rust() {
+        let code = super::marigold_parse("range(0, 5).return").expect("should parse");
+        assert!(code.contains("async"));
     }
 }

--- a/marigold-impl/src/keep_first_n.rs
+++ b/marigold-impl/src/keep_first_n.rs
@@ -45,14 +45,13 @@ where
     }
 }
 
-/// Internal logic for keep_first_n. This is in a separate function so that we can get the full
-/// type of the binary heap, which includes a lambda for reversing the ordering fromt the passed
-/// sort_by function. By declaring a new function, we can use generics to describe its type, and
-/// then can use that type while unsafely casting pointers.
+/// Internal logic for keep_first_n. This is a separate function so that Rust can infer the full
+/// type of the reversed-comparator binary heap via generics. The heap type includes the concrete
+/// lambda type of the reversed ordering, which cannot be named at the call site.
 ///
-/// This implementation wraps items with their stream index to provide deterministic tie-breaking
-/// when the user's comparison function returns Equal. Lower indices (earlier in stream) are
-/// preferred to ensure consistent results even with parallel processing.
+/// Items are wrapped with their stream index to provide deterministic tie-breaking when the
+/// caller's comparator returns `Equal`. Lower indices (earlier in the stream) are preferred,
+/// ensuring consistent results across runs even with concurrent processing.
 #[cfg(any(feature = "tokio", feature = "async-std"))]
 async fn impl_keep_first_n<SInput, T, F, FReversed>(
     sinput: SInput,

--- a/marigold-impl/src/multi_consumer_stream.rs
+++ b/marigold-impl/src/multi_consumer_stream.rs
@@ -10,6 +10,9 @@ use futures::stream::StreamExt;
 use futures::task::Context;
 use futures::task::Poll;
 
+// Buffer size of 1 creates back-pressure: the driver won't read the next item from the inner
+// stream until every consumer has accepted the current one. This keeps memory usage O(consumers)
+// rather than O(stream_length) at the cost of throughput when consumers lag.
 const BUFFER_SIZE: usize = 1;
 
 pub struct MultiConsumerStream<

--- a/marigold-macros/src/lib.rs
+++ b/marigold-macros/src/lib.rs
@@ -4,6 +4,10 @@ extern crate proc_macro;
 use marigold_grammar::marigold_parse;
 use proc_macro::TokenStream;
 
+/// The `m!` macro — compile Marigold DSL into Rust at build time.
+///
+/// The `.parse().unwrap()` is safe: `marigold_parse` guarantees the returned string is
+/// valid Rust token syntax, so parsing it as a `TokenStream` cannot fail.
 #[proc_macro]
 pub fn marigold(item: TokenStream) -> TokenStream {
     let s = item.to_string();

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -110,56 +110,8 @@ mod tests {
         );
     }
 
-    // Note: This test is disabled until the `io` feature is enabled in tests/Cargo.toml
-    // and the Pest parser implementation for read_file is complete.
-    // This test documents the expected behavior for the read_file integration test.
-    //
-    // #[tokio::test]
-    // async fn test_read_file_csv() {
-    //     use std::io::Write;
-    //
-    //     #[derive(Debug, serde::Deserialize, PartialEq)]
-    //     struct TestData {
-    //         id: i32,
-    //         name: String,
-    //     }
-    //
-    //     let temp_dir = std::env::temp_dir();
-    //     let file_path = temp_dir.join("test_data.csv");
-    //     let file_path_str = file_path.to_str().unwrap();
-    //
-    //     {
-    //         let mut file = std::fs::File::create(&file_path).unwrap();
-    //         writeln!(file, "id,name").unwrap();
-    //         writeln!(file, "1,Alice").unwrap();
-    //         writeln!(file, "2,Bob").unwrap();
-    //     }
-    //
-    //     let result = m!(
-    //         read_file(file_path_str, csv, struct=TestData).return
-    //     )
-    //     .await
-    //     .collect::<Vec<Result<TestData, _>>>()
-    //     .await;
-    //
-    //     std::fs::remove_file(&file_path).ok();
-    //
-    //     assert_eq!(result.len(), 2);
-    //     assert_eq!(
-    //         result[0].as_ref().unwrap(),
-    //         &TestData {
-    //             id: 1,
-    //             name: "Alice".to_string()
-    //         }
-    //     );
-    //     assert_eq!(
-    //         result[1].as_ref().unwrap(),
-    //         &TestData {
-    //             id: 2,
-    //             name: "Bob".to_string()
-    //         }
-    //     );
-    // }
+    // TODO: add a test_read_file_csv integration test once the `io` feature is enabled
+    // in tests/Cargo.toml (tracked in the open issue for read_file support).
 
     #[tokio::test]
     async fn test_enum_range() {


### PR DESCRIPTION
## Summary

This PR improves documentation clarity without changing any behavior.

**`marigold-grammar/src/lib.rs`**:
- Replaced a 60-line module doc containing unverified performance numbers ("< 1ms", "~40KB"), a stale reference to the removed `get_parser()` function, and generic boilerplate with a concise table-driven overview of the six modules
- Shortened the `marigold_parse` doc from a multi-paragraph description to a one-sentence + example form
- Added missing doc comment to `marigold_analyze`
- Replaced the `2 + 2` placeholder test with a meaningful parse smoke test

**`marigold-impl/src/keep_first_n.rs`**:
- Fixed typo "fromt" → "from" in `impl_keep_first_n` doc
- Removed the false claim that the function "unsafely casts pointers" — the current implementation uses only safe Rust generics; the unsafe pointer cast was part of an older implementation that was replaced

**`marigold-impl/src/multi_consumer_stream.rs`**:
- Added a comment explaining why `BUFFER_SIZE = 1` (back-pressure: prevents buffering the entire stream in memory when consumers are slow)

**`marigold-macros/src/lib.rs`**:
- Added a doc comment for the `m!` proc-macro explaining why the `.unwrap()` on the generated `TokenStream` is safe

**`tests/src/lib.rs`**:
- Replaced a 50-line block of commented-out test code with a two-line TODO comment. The commented code was gated on an `io` feature not enabled in this crate, so it could never run and provided only noise to readers

## Test plan

- [ ] `cargo check --workspace` passes
- [ ] `cargo test -p tests` passes (integration tests unaffected)
- [ ] `cargo test -p marigold-grammar` passes

https://claude.ai/code/session_015qvaT243enNQXYo7QXJudF