### PR TITLE
Add tests: MultiConsumerStream, Combinable edge cases, Marifold, m! integration

### DIFF
--- a/marigold-impl/src/combinations.rs
+++ b/marigold-impl/src/combinations.rs
@@ -48,4 +48,74 @@ mod tests {
             vec![vec![1, 2], vec![1, 3], vec![2, 3],]
         );
     }
+
+    /// k=0 yields exactly one combination: the empty set.
+    #[tokio::test]
+    async fn k_zero_yields_one_empty_combination() {
+        let result = futures::stream::iter(vec![1i32, 2, 3])
+            .combinations(0)
+            .await
+            .collect::<Vec<_>>()
+            .await;
+        assert_eq!(result, vec![vec![] as Vec<i32>]);
+    }
+
+    /// k=1 is equivalent to wrapping each element in a singleton vec.
+    #[tokio::test]
+    async fn k_one_yields_singletons() {
+        let result = futures::stream::iter(vec![10i32, 20, 30])
+            .combinations(1)
+            .await
+            .collect::<Vec<_>>()
+            .await;
+        assert_eq!(result, vec![vec![10], vec![20], vec![30]]);
+    }
+
+    /// k=n (take all items) yields exactly one combination containing all elements.
+    #[tokio::test]
+    async fn k_equals_n_yields_one_full_combination() {
+        let result = futures::stream::iter(vec![1i32, 2, 3])
+            .combinations(3)
+            .await
+            .collect::<Vec<_>>()
+            .await;
+        assert_eq!(result, vec![vec![1, 2, 3]]);
+    }
+
+    /// k > n yields no combinations (not enough elements to form any group).
+    #[tokio::test]
+    async fn k_greater_than_n_yields_nothing() {
+        let result = futures::stream::iter(vec![1i32, 2])
+            .combinations(5)
+            .await
+            .collect::<Vec<_>>()
+            .await;
+        assert!(
+            result.is_empty(),
+            "expected no combinations when k > n, got {result:?}"
+        );
+    }
+
+    /// An empty source stream with any k > 0 yields no combinations.
+    #[tokio::test]
+    async fn empty_source_yields_nothing() {
+        let result = futures::stream::iter(Vec::<i32>::new())
+            .combinations(2)
+            .await
+            .collect::<Vec<_>>()
+            .await;
+        assert!(result.is_empty());
+    }
+
+    /// combinations(k) produces exactly C(n, k) results (count invariant).
+    #[tokio::test]
+    async fn count_matches_binomial_coefficient() {
+        // C(6, 3) = 20
+        let result = futures::stream::iter(0i32..6)
+            .combinations(3)
+            .await
+            .collect::<Vec<_>>()
+            .await;
+        assert_eq!(result.len(), 20);
+    }
 }

--- a/marigold-impl/src/marifold.rs
+++ b/marigold-impl/src/marifold.rs
@@ -50,4 +50,66 @@ mod tests {
             vec![10]
         );
     }
+
+    /// An empty stream produces exactly one item: the initial accumulator value.
+    #[tokio::test]
+    async fn empty_stream_returns_init() {
+        let result = futures::stream::iter(Vec::<i32>::new())
+            .marifold(99i32, |acc, x| async move { acc + x })
+            .await
+            .collect::<Vec<i32>>()
+            .await;
+        assert_eq!(result, vec![99]);
+    }
+
+    /// A single-element stream folds correctly with the initial value.
+    #[tokio::test]
+    async fn single_element_fold() {
+        let result = futures::stream::iter(vec![7i32])
+            .marifold(3i32, |acc, x| async move { acc + x })
+            .await
+            .collect::<Vec<i32>>()
+            .await;
+        assert_eq!(result, vec![10]);
+    }
+
+    /// The output is always a stream of exactly one element, regardless of input length.
+    #[tokio::test]
+    async fn output_is_always_single_element() {
+        for n in [0usize, 1, 10, 100] {
+            let count = futures::stream::iter(0..n)
+                .marifold(0usize, |acc, _| async move { acc + 1 })
+                .await
+                .collect::<Vec<_>>()
+                .await
+                .len();
+            assert_eq!(count, 1, "expected exactly 1 output item for n={n}");
+        }
+    }
+
+    /// Non-commutative fold (subtraction) validates that ordering is preserved.
+    #[tokio::test]
+    async fn non_commutative_fold_preserves_order() {
+        // 0 - 1 - 2 - 3 = -6
+        let result = futures::stream::iter(1i32..=3)
+            .marifold(0i32, |acc, x| async move { acc - x })
+            .await
+            .collect::<Vec<i32>>()
+            .await;
+        assert_eq!(result, vec![-6]);
+    }
+
+    /// String concatenation confirms the fold works with non-numeric state.
+    #[tokio::test]
+    async fn string_accumulation() {
+        let result = futures::stream::iter(vec!["b", "c", "d"])
+            .marifold("a".to_string(), |mut acc, x| async move {
+                acc.push_str(x);
+                acc
+            })
+            .await
+            .collect::<Vec<String>>()
+            .await;
+        assert_eq!(result, vec!["abcd"]);
+    }
 }

--- a/marigold-impl/src/multi_consumer_stream.rs
+++ b/marigold-impl/src/multi_consumer_stream.rs
@@ -100,3 +100,78 @@ impl<T: std::marker::Send + Unpin + 'static, O, F: Future<Output = O>> Stream
         (0, None)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{MultiConsumerStream, RunFutureAsStream};
+    use futures::stream::StreamExt;
+
+    /// A single consumer receives every item from the source stream.
+    #[tokio::test]
+    async fn single_consumer_receives_all_items() {
+        let source = futures::stream::iter(vec![1u32, 2, 3, 4, 5]);
+        let mut mcs = MultiConsumerStream::new(source);
+        let rx = mcs.get();
+        mcs.run().await;
+        let result: Vec<u32> = rx.collect().await;
+        assert_eq!(result, vec![1, 2, 3, 4, 5]);
+    }
+
+    /// Two independent consumers each receive a complete, identical copy of the stream.
+    /// Both receivers are drained concurrently via tokio::join! to avoid deadlock
+    /// (the channel buffer is 1, so sequential drain would block the producer).
+    #[tokio::test]
+    async fn two_consumers_each_receive_full_stream() {
+        let source = futures::stream::iter(vec![10u32, 20, 30]);
+        let mut mcs = MultiConsumerStream::new(source);
+        let rx1 = mcs.get();
+        let rx2 = mcs.get();
+        mcs.run().await;
+        let (r1, r2) = tokio::join!(rx1.collect::<Vec<u32>>(), rx2.collect::<Vec<u32>>(),);
+        assert_eq!(r1, vec![10, 20, 30]);
+        assert_eq!(r2, vec![10, 20, 30]);
+    }
+
+    /// An empty source stream cleanly terminates all consumer channels.
+    #[tokio::test]
+    async fn empty_source_terminates_consumers() {
+        let source = futures::stream::iter(Vec::<u32>::new());
+        let mut mcs = MultiConsumerStream::new(source);
+        let rx = mcs.get();
+        mcs.run().await;
+        let result: Vec<u32> = rx.collect().await;
+        assert!(result.is_empty());
+    }
+
+    /// A single-element source stream is forwarded correctly.
+    #[tokio::test]
+    async fn single_item_forwarded() {
+        let source = futures::stream::iter(vec![42u32]);
+        let mut mcs = MultiConsumerStream::new(source);
+        let rx = mcs.get();
+        mcs.run().await;
+        let result: Vec<u32> = rx.collect().await;
+        assert_eq!(result, vec![42]);
+    }
+
+    /// A completed future produces no items and immediately terminates the stream.
+    #[tokio::test]
+    async fn run_future_as_stream_produces_no_items() {
+        let fut = Box::pin(async { 42u32 });
+        let stream: RunFutureAsStream<u32, u32, _> = RunFutureAsStream::new(fut);
+        let items: Vec<u32> = stream.collect().await;
+        assert!(
+            items.is_empty(),
+            "RunFutureAsStream should yield no items; got {items:?}"
+        );
+    }
+
+    /// size_hint always reports (0, None) because the future resolves to no stream items.
+    #[tokio::test]
+    async fn run_future_as_stream_size_hint() {
+        use futures::Stream;
+        let fut = Box::pin(async { () });
+        let stream: RunFutureAsStream<u32, (), _> = RunFutureAsStream::new(fut);
+        assert_eq!(stream.size_hint(), (0, None));
+    }
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -218,4 +218,86 @@ mod tests {
         .await;
         assert_eq!(result, vec![0, 1, 2, 3]);
     }
+
+    // combinations via m!
+    // Note: the m! macro generates fixed-size array outputs for combinations;
+    // type annotations use array syntax [T; k].
+
+    /// Combinations of range(0, 4) choose 2 should yield C(4,2) = 6 items.
+    #[tokio::test]
+    async fn test_combinations_count() {
+        let result = m!(
+            range(0, 4).combinations(2).return
+        )
+        .await
+        .collect::<Vec<[i32; 2]>>()
+        .await;
+        assert_eq!(result.len(), 6);
+    }
+
+    /// Combinations in lexicographic order from range(0, 3) choose 2.
+    #[tokio::test]
+    async fn test_combinations_values() {
+        let result = m!(
+            range(0, 3).combinations(2).return
+        )
+        .await
+        .collect::<Vec<[i32; 2]>>()
+        .await;
+        assert_eq!(result, [[0i32, 1], [0, 2], [1, 2]]);
+    }
+
+    // keep_first_n via m!
+    // Note: the m! macro grammar requires a named comparator function, not an inline closure.
+
+    /// keep_first_n retains the N largest elements in descending order.
+    #[tokio::test]
+    async fn test_keep_first_n_largest() {
+        let by_value = |a: &i32, b: &i32| a.cmp(b);
+        let result = m!(
+            range(0, 10).keep_first_n(3, by_value).return
+        )
+        .await
+        .collect::<Vec<_>>()
+        .await;
+        assert_eq!(result, vec![9, 8, 7]);
+    }
+
+    /// keep_first_n when n >= stream length returns all items in descending order.
+    #[tokio::test]
+    async fn test_keep_first_n_larger_than_stream() {
+        let by_value = |a: &i32, b: &i32| a.cmp(b);
+        let result = m!(
+            range(0, 4).keep_first_n(10, by_value).return
+        )
+        .await
+        .collect::<Vec<_>>()
+        .await;
+        assert_eq!(result, vec![3, 2, 1, 0]);
+    }
+
+    // chained map + filter via m!
+
+    /// Applying map then filter composes correctly end-to-end.
+    #[tokio::test]
+    async fn test_map_then_filter() {
+        fn double(v: i32) -> i32 {
+            v * 2
+        }
+        fn is_gt_four(v: i32) -> bool {
+            v > 4
+        }
+
+        let result = m!(
+            range(0, 6)
+                .map(double)
+                .filter(is_gt_four)
+                .return
+        )
+        .await
+        .collect::<Vec<_>>()
+        .await;
+        // doubled: 0,2,4,6,8,10  then filtered >4: 6,8,10
+        assert_eq!(result, vec![6, 8, 10]);
+    }
 }


### PR DESCRIPTION
## What part of the code was chosen and why?

Four areas were selected based on a full audit of the test suite:

1. **`marigold-impl/src/multi_consumer_stream.rs`** — `MultiConsumerStream` and `RunFutureAsStream` had **zero tests**. `MultiConsumerStream` is the core fan-out primitive used by the multi-consumer pipeline feature; `RunFutureAsStream` is the adapter that makes a side-effecting future behave as a stream. Both are non-trivial async types deserving explicit coverage.

2. **`marigold-impl/src/combinations.rs`** — Only a single happy-path test existed (`k=2` from `[1,2,3]`). The `Combinable` trait wraps itertools and has well-defined mathematical boundary conditions that were entirely untested.

3. **`marigold-impl/src/marifold.rs`** — One test (summing `0..5`). The fold-to-single-stream adapter has several important invariants (always-one-output, empty-stream identity, ordering) that were undocumented by tests.

4. **`tests/src/lib.rs` (integration)** — The top-level `tests` crate exercises the `m!` macro end-to-end but had no tests for `combinations`, `keep_first_n`, `map+filter` chains, or boundary cases.

## Current test disposition

| Module | Tests before | Tests after |
|---|---|---|
| `multi_consumer_stream` | 0 | 6 |
| `combinations` | 1 | 7 |
| `marifold` | 1 | 6 |
| `tests` (integration) | 10 | 15 |
| **Total** | **12** | **34** |

## Key invariants validated

### `MultiConsumerStream`
- A single consumer receives every item from the source stream (happy path).
- Two consumers each receive a **complete, independent copy** of the stream when drained concurrently via `tokio::join!` (fan-out correctness; sequential drain would deadlock at `BUFFER_SIZE=1`).
- An empty source terminates all consumer channels cleanly.
- A single-item source is forwarded correctly.

### `RunFutureAsStream`
- A completed future yields **zero stream items** (the invariant of this adapter: it is used for side effects, not values).
- `size_hint()` always reports `(0, None)`.

### `Combinable` (edge cases)
- `k=0` yields exactly one combination — the empty set.
- `k=1` wraps each element as a singleton.
- `k=n` yields exactly one combination containing all elements.
- `k>n` yields no combinations (insufficient elements).
- Empty source with any `k>0` yields nothing.
- `combinations(k)` produces exactly `C(n,k)` results (count invariant).

### `Marifold`
- Empty stream returns exactly the initial accumulator (identity).
- Single-element stream folds with the initial value correctly.
- Output is **always exactly one element**, regardless of input length.
- Non-commutative fold (subtraction) validates left-to-right ordering.
- String accumulation confirms the fold works with non-numeric state.

### Integration (`m!` macro)
- `combinations` count and lexicographic ordering through the DSL.
- `keep_first_n` returns top-N in descending order; handles `n >= length`.
- `map` followed by `filter` composes correctly end-to-end.

https://claude.ai/code/session_018Uk9aCCyjsv4r1aGQr7SV7