### PR TITLE
test: edge-case tests for combinations and permutations stream adapters

### DIFF
--- a/marigold-impl/src/combinations.rs
+++ b/marigold-impl/src/combinations.rs
@@ -38,14 +38,68 @@ mod tests {
     use futures::stream::StreamExt;
 
     #[tokio::test]
-    async fn combinations() {
+    async fn combinations_basic() {
         assert_eq!(
             futures::stream::iter(vec![1, 2, 3])
                 .combinations(2)
                 .await
                 .collect::<Vec<_>>()
                 .await,
-            vec![vec![1, 2], vec![1, 3], vec![2, 3],]
+            vec![vec![1, 2], vec![1, 3], vec![2, 3]]
         );
+    }
+
+    #[tokio::test]
+    async fn combinations_k_zero() {
+        // k=0 yields exactly one combination: the empty set
+        let result: Vec<Vec<i32>> = futures::stream::iter(vec![1, 2, 3])
+            .combinations(0)
+            .await
+            .collect::<Vec<_>>()
+            .await;
+        assert_eq!(result, vec![Vec::<i32>::new()]);
+    }
+
+    #[tokio::test]
+    async fn combinations_k_equals_length() {
+        // k = len yields exactly one combination containing all elements
+        let result: Vec<Vec<i32>> = futures::stream::iter(vec![1, 2, 3])
+            .combinations(3)
+            .await
+            .collect::<Vec<_>>()
+            .await;
+        assert_eq!(result, vec![vec![1, 2, 3]]);
+    }
+
+    #[tokio::test]
+    async fn combinations_k_exceeds_length() {
+        // k > len yields nothing
+        let result: Vec<Vec<i32>> = futures::stream::iter(vec![1, 2])
+            .combinations(5)
+            .await
+            .collect::<Vec<_>>()
+            .await;
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn combinations_empty_stream() {
+        let result: Vec<Vec<i32>> = futures::stream::iter(Vec::<i32>::new())
+            .combinations(2)
+            .await
+            .collect::<Vec<_>>()
+            .await;
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn combinations_count() {
+        // C(5,2) = 10
+        let result: Vec<Vec<i32>> = futures::stream::iter(vec![1, 2, 3, 4, 5])
+            .combinations(2)
+            .await
+            .collect::<Vec<_>>()
+            .await;
+        assert_eq!(result.len(), 10);
     }
 }

--- a/marigold-impl/src/permutations.rs
+++ b/marigold-impl/src/permutations.rs
@@ -57,7 +57,7 @@ mod tests {
     use futures::stream::StreamExt;
 
     #[tokio::test]
-    async fn permutations() {
+    async fn permutations_basic() {
         assert_eq!(
             futures::stream::iter(vec![1, 2, 3])
                 .permutations(2)
@@ -76,7 +76,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn permutations_with_replacement() {
+    async fn permutations_with_replacement_basic() {
         assert_eq!(
             futures::stream::iter(vec![0, 1, 2])
                 .permutations_with_replacement(2)
@@ -95,5 +95,59 @@ mod tests {
                 vec![2, 2],
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn permutations_k_zero() {
+        // k=0 yields exactly one permutation: the empty sequence
+        let result: Vec<Vec<i32>> = futures::stream::iter(vec![1, 2, 3])
+            .permutations(0)
+            .await
+            .collect::<Vec<_>>()
+            .await;
+        assert_eq!(result, vec![Vec::<i32>::new()]);
+    }
+
+    #[tokio::test]
+    async fn permutations_k_exceeds_length() {
+        // k > len yields nothing
+        let result: Vec<Vec<i32>> = futures::stream::iter(vec![1, 2])
+            .permutations(5)
+            .await
+            .collect::<Vec<_>>()
+            .await;
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn permutations_empty_stream() {
+        let result: Vec<Vec<i32>> = futures::stream::iter(Vec::<i32>::new())
+            .permutations(2)
+            .await
+            .collect::<Vec<_>>()
+            .await;
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn permutations_count() {
+        // P(4,2) = 4!/(4-2)! = 12
+        let result: Vec<Vec<i32>> = futures::stream::iter(vec![1, 2, 3, 4])
+            .permutations(2)
+            .await
+            .collect::<Vec<_>>()
+            .await;
+        assert_eq!(result.len(), 12);
+    }
+
+    #[tokio::test]
+    async fn permutations_with_replacement_empty_stream() {
+        // empty stream yields nothing regardless of k
+        let result: Vec<Vec<i32>> = futures::stream::iter(Vec::<i32>::new())
+            .permutations_with_replacement(2)
+            .await
+            .collect::<Vec<_>>()
+            .await;
+        assert!(result.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

**Component**: `marigold-impl` — `Combinable` and `Permutable` stream adapters

**Current disposition**: Both modules had only one happy-path test each, covering
a single non-trivial input. No edge cases were exercised.

**Key invariants now validated**:

| Invariant | Test |
|-----------|------|
| `combinations(k=0)` yields one empty-set combination | `combinations_k_zero` |
| `combinations(k=len)` yields one all-elements combination | `combinations_k_equals_length` |
| `combinations(k > len)` yields nothing | `combinations_k_exceeds_length` |
| Empty stream + any k yields nothing | `combinations_empty_stream` |
| C(5,2) = 10 (count invariant) | `combinations_count` |
| `permutations(k=0)` yields one empty-sequence permutation | `permutations_k_zero` |
| `permutations(k > len)` yields nothing | `permutations_k_exceeds_length` |
| Empty stream + any k yields nothing | `permutations_empty_stream` |
| P(4,2) = 12 (count invariant) | `permutations_count` |
| Empty stream for `permutations_with_replacement` | `permutations_with_replacement_empty_stream` |

**Strategy**: Unit tests using `#[tokio::test]` in the existing `#[cfg(test)]`
modules, consistent with the project's existing test style.