### PR TITLE
arch(marigold): reduce complexity and improve alignment

### DIFF
--- a/marigold-grammar/src/lib.rs
+++ b/marigold-grammar/src/lib.rs
@@ -97,12 +97,3 @@ pub fn marigold_analyze(
 ) -> Result<complexity::ProgramComplexity, parser::MarigoldParseError> {
     parser::PestParser::analyze(s)
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 4);
-    }
-}

--- a/marigold-impl/src/async_runtime.rs
+++ b/marigold-impl/src/async_runtime.rs
@@ -1,4 +1,5 @@
-#[cfg(all(feature = "tokio", not(feature = "async-std")))]
+// When only tokio is enabled, or when both are enabled (tokio takes precedence).
+#[cfg(feature = "tokio")]
 pub fn spawn<T>(future: T) -> tokio::task::JoinHandle<T::Output>
 where
     T: std::future::Future + Send + 'static,
@@ -14,14 +15,4 @@ where
     T::Output: Send + 'static,
 {
     async_std::task::spawn(future)
-}
-
-// When both features are enabled, tokio takes precedence
-#[cfg(all(feature = "tokio", feature = "async-std"))]
-pub fn spawn<T>(future: T) -> tokio::task::JoinHandle<T::Output>
-where
-    T: std::future::Future + Send + 'static,
-    T::Output: Send + 'static,
-{
-    tokio::spawn(future)
 }

--- a/marigold-impl/src/keep_first_n.rs
+++ b/marigold-impl/src/keep_first_n.rs
@@ -35,28 +35,22 @@ where
 {
     #[instrument(skip(self, sorted_by))]
     async fn keep_first_n(
-        mut self,
+        self,
         n: usize,
         sorted_by: F,
     ) -> futures::stream::Iter<std::vec::IntoIter<T>> {
-        // use the reverse ordering so that the smallest value is always the first to pop.
-        let first_n = BinaryHeap::with_capacity_by(n, move |a, b| sorted_by(a, b).reverse());
-        impl_keep_first_n(self, first_n, n, sorted_by).await
+        impl_keep_first_n(self, n, sorted_by).await
     }
 }
 
-/// Internal logic for keep_first_n. This is in a separate function so that we can get the full
-/// type of the binary heap, which includes a lambda for reversing the ordering fromt the passed
-/// sort_by function. By declaring a new function, we can use generics to describe its type, and
-/// then can use that type while unsafely casting pointers.
+/// Core implementation of keep_first_n.
 ///
 /// This implementation wraps items with their stream index to provide deterministic tie-breaking
 /// when the user's comparison function returns Equal. Lower indices (earlier in stream) are
 /// preferred to ensure consistent results even with parallel processing.
 #[cfg(any(feature = "tokio", feature = "async-std"))]
-async fn impl_keep_first_n<SInput, T, F, FReversed>(
+async fn impl_keep_first_n<SInput, T, F>(
     sinput: SInput,
-    _first_n: BinaryHeap<T, binary_heap_plus::FnComparator<FReversed>>,
     n: usize,
     sorted_by: F,
 ) -> futures::stream::Iter<std::vec::IntoIter<T>>
@@ -64,12 +58,12 @@ where
     SInput: Stream<Item = T> + Send + Unpin + std::marker::Sync + 'static,
     T: Clone + Send + std::marker::Sync + std::fmt::Debug + 'static,
     F: Fn(&T, &T) -> Ordering + std::marker::Send + std::marker::Sync + std::marker::Copy + 'static,
-    FReversed: Fn(&T, &T) -> std::cmp::Ordering + Clone + Send + 'static,
 {
     // Add indices to items for deterministic tie-breaking
     let mut indexed_stream = sinput.enumerate();
 
-    // Create a heap that stores (index, item) tuples with tie-breaking comparator
+    // Create a heap that stores (index, item) tuples with tie-breaking comparator.
+    // The heap is min-oriented (reverse of sorted_by) so peek() returns the smallest kept item.
     let indexed_comparator = move |a: &(usize, T), b: &(usize, T)| {
         match sorted_by(&a.1, &b.1) {
             Ordering::Less => Ordering::Less,


### PR DESCRIPTION
## Issues found and addressed

### 1. Dead phantom parameter in `impl_keep_first_n` (`marigold-impl/src/keep_first_n.rs`)

**Problem:** The parallel path of `keep_first_n` had a helper function `impl_keep_first_n` that accepted a `_first_n: BinaryHeap<T, binary_heap_plus::FnComparator<FReversed>>` parameter. This parameter was:
- immediately dropped on entry (never read or used)
- named with a leading `_` acknowledging it was unused
- present only to thread the `FReversed` type parameter through generics, which is now unnecessary because the heap is reconstructed from scratch inside the function body

The comment above the function ("This is in a separate function so that we can get the full type of the binary heap... then can use that type while unsafely casting pointers") referred to a previous implementation involving raw pointer casts that no longer exists. The current code does not cast any pointers and does not need the phantom parameter.

**Fix:** Removed the `_first_n` parameter, the now-unused `FReversed` type parameter from the function signature, and the now-stale comment. The call site in the `KeepFirstN` impl no longer constructs and immediately discards a heap just to pass it in.

**Lines removed:** ~10 lines of dead code; the pre-constructed-and-discarded heap allocation is eliminated.

### 2. Redundant third `spawn` variant in `async_runtime.rs`

**Problem:** `async_runtime.rs` had three `#[cfg]`-gated `spawn` functions:
1. `#[cfg(all(feature = "tokio", not(feature = "async-std")))]` — tokio only
2. `#[cfg(all(feature = "async-std", not(feature = "tokio")))]` — async-std only
3. `#[cfg(all(feature = "tokio", feature = "async-std"))]` — both enabled

The third variant was byte-for-byte identical to the first (`tokio::spawn`). The first variant's guard already excluded the both-enabled case via `not(feature = "async-std")`, so the third existed solely to cover that gap — but a simpler `#[cfg(feature = "tokio")]` guard on a single function covers both "tokio only" and "both enabled" in one definition.

**Fix:** Collapsed the first and third variants into a single `#[cfg(feature = "tokio")]` function, removing ~10 lines of duplication and the misleading "When both features are enabled, tokio takes precedence" comment (this is now self-evident from the cfg ordering).

### 3. Placeholder `it_works` test in `marigold-grammar/src/lib.rs`

**Problem:** The crate-level `lib.rs` contained:
```rust
#[cfg(test)]
mod tests {
    #[test]
    fn it_works() {
        let result = 2 + 2;
        assert_eq!(result, 4);
    }
}
```
This is a cargo-new boilerplate stub that was never replaced. It adds noise to `cargo test` output, contributes nothing to confidence in the grammar crate, and implicitly suggests the crate lacks real tests (it has many in submodules and in `marigold-grammar/tests/`).

**Fix:** Removed the entire stub test block.
