### PR TITLE
test(marigold): improve coverage and test quality

### DIFF
--- a/marigold-grammar/src/type_aggregation.rs
+++ b/marigold-grammar/src/type_aggregation.rs
@@ -26,3 +26,96 @@ pub fn aggregate_input_count<I: IntoIterator<Item = nodes::InputCount>>(
     }
     nodes::InputCount::Known(total_count)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::nodes::{InputCount, InputVariability};
+    use num_bigint::BigUint;
+
+    // ---- aggregate_input_variability ----
+
+    /// All-Constant inputs aggregate to Constant.
+    #[test]
+    fn variability_all_constant() {
+        let result = aggregate_input_variability(vec![
+            InputVariability::Constant,
+            InputVariability::Constant,
+        ]);
+        assert_eq!(result, InputVariability::Constant);
+    }
+
+    /// Any Variable in the input makes the aggregate Variable.
+    #[test]
+    fn variability_any_variable_dominates() {
+        let result = aggregate_input_variability(vec![
+            InputVariability::Constant,
+            InputVariability::Variable,
+            InputVariability::Constant,
+        ]);
+        assert_eq!(result, InputVariability::Variable);
+    }
+
+    /// A single Variable input returns Variable.
+    #[test]
+    fn variability_single_variable() {
+        let result =
+            aggregate_input_variability(std::iter::once(InputVariability::Variable));
+        assert_eq!(result, InputVariability::Variable);
+    }
+
+    /// An empty iterator (no inputs) returns Constant (vacuously true).
+    #[test]
+    fn variability_empty_is_constant() {
+        let result = aggregate_input_variability(Vec::<InputVariability>::new());
+        assert_eq!(result, InputVariability::Constant);
+    }
+
+    // ---- aggregate_input_count ----
+
+    /// Known counts are summed correctly.
+    #[test]
+    fn count_known_values_are_summed() {
+        let result = aggregate_input_count(vec![
+            InputCount::Known(BigUint::from(3u32)),
+            InputCount::Known(BigUint::from(7u32)),
+        ]);
+        assert_eq!(result, InputCount::Known(BigUint::from(10u32)));
+    }
+
+    /// A single Unknown in the inputs makes the whole result Unknown.
+    #[test]
+    fn count_unknown_dominates() {
+        let result = aggregate_input_count(vec![
+            InputCount::Known(BigUint::from(5u32)),
+            InputCount::Unknown,
+            InputCount::Known(BigUint::from(3u32)),
+        ]);
+        assert_eq!(result, InputCount::Unknown);
+    }
+
+    /// An Enum variant (unresolved) also makes the result Unknown.
+    #[test]
+    fn count_unresolved_enum_returns_unknown() {
+        let result = aggregate_input_count(vec![
+            InputCount::Known(BigUint::from(2u32)),
+            InputCount::Enum("Color".to_string()),
+        ]);
+        assert_eq!(result, InputCount::Unknown);
+    }
+
+    /// An empty iterator returns Known(0).
+    #[test]
+    fn count_empty_is_zero() {
+        let result = aggregate_input_count(Vec::<InputCount>::new());
+        assert_eq!(result, InputCount::Known(BigUint::from(0u32)));
+    }
+
+    /// A single Known count passes through unchanged.
+    #[test]
+    fn count_single_known() {
+        let result =
+            aggregate_input_count(std::iter::once(InputCount::Known(BigUint::from(42u32))));
+        assert_eq!(result, InputCount::Known(BigUint::from(42u32)));
+    }
+}

--- a/marigold-impl/src/collect_and_apply.rs
+++ b/marigold-impl/src/collect_and_apply.rs
@@ -31,11 +31,38 @@ mod tests {
     use super::CollectAndAppliable;
 
     #[tokio::test]
-    async fn collect_and_apply() {
+    async fn collect_and_apply_basic() {
         assert_eq!(
             futures::stream::iter(1..=3).collect_and_apply(|x| x).await,
             vec![1, 2, 3]
         );
+    }
+
+    /// An empty stream delivers an empty Vec to the applied function.
+    #[tokio::test]
+    async fn collect_and_apply_empty_stream() {
+        let result: Vec<i32> = futures::stream::iter(Vec::<i32>::new())
+            .collect_and_apply(|v| v)
+            .await;
+        assert!(result.is_empty());
+    }
+
+    /// The applied function can transform the collected data arbitrarily.
+    #[tokio::test]
+    async fn collect_and_apply_transform() {
+        let sum: i32 = futures::stream::iter(vec![1i32, 2, 3, 4])
+            .collect_and_apply(|v| v.iter().sum())
+            .await;
+        assert_eq!(sum, 10);
+    }
+
+    /// A single-element stream passes a one-element Vec.
+    #[tokio::test]
+    async fn collect_and_apply_single_element() {
+        let result: Vec<u8> = futures::stream::iter(vec![99u8])
+            .collect_and_apply(|v| v)
+            .await;
+        assert_eq!(result, vec![99u8]);
     }
 
     #[tokio::test]

--- a/marigold-impl/src/marifold.rs
+++ b/marigold-impl/src/marifold.rs
@@ -39,6 +39,7 @@ mod tests {
     use super::Marifold;
     use futures::stream::StreamExt;
 
+    /// Basic fold: sum 0..5 = 10.
     #[tokio::test]
     async fn fold() {
         assert_eq!(
@@ -49,5 +50,41 @@ mod tests {
                 .await,
             vec![10]
         );
+    }
+
+    /// Folding an empty stream returns the initial accumulator as the sole item.
+    #[tokio::test]
+    async fn fold_empty_stream_returns_init() {
+        let result: Vec<i32> = futures::stream::iter(Vec::<i32>::new())
+            .marifold(42, |acc, x| async move { acc + x })
+            .await
+            .collect()
+            .await;
+        assert_eq!(result, vec![42]);
+    }
+
+    /// Folding a single-element stream applies the function exactly once.
+    #[tokio::test]
+    async fn fold_single_element() {
+        let result: Vec<i32> = futures::stream::iter(vec![7i32])
+            .marifold(0, |acc, x| async move { acc + x })
+            .await
+            .collect()
+            .await;
+        assert_eq!(result, vec![7]);
+    }
+
+    /// marifold always produces exactly one output item regardless of input length.
+    #[tokio::test]
+    async fn fold_always_produces_one_item() {
+        for len in [0usize, 1, 10, 100] {
+            let count: usize = futures::stream::iter(vec![1u32; len])
+                .marifold(0u32, |acc, x| async move { acc + x })
+                .await
+                .collect::<Vec<_>>()
+                .await
+                .len();
+            assert_eq!(count, 1, "expected 1 item for input length {len}");
+        }
     }
 }

--- a/marigold-impl/src/multi_consumer_stream.rs
+++ b/marigold-impl/src/multi_consumer_stream.rs
@@ -100,3 +100,71 @@ impl<T: std::marker::Send + Unpin + 'static, O, F: Future<Output = O>> Stream
         (0, None)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream::StreamExt;
+
+    // ---- MultiConsumerStream ----
+
+    /// A single consumer receives all items produced by the inner stream.
+    #[tokio::test]
+    async fn multi_consumer_single_consumer_receives_all_items() {
+        let items = vec![1u32, 2, 3];
+        let mut mcs = MultiConsumerStream::new(futures::stream::iter(items.clone()));
+        let receiver = mcs.get();
+        mcs.run().await;
+
+        let collected: Vec<u32> = receiver.collect().await;
+        assert_eq!(collected, items);
+    }
+
+    /// Two consumers each independently receive every item (broadcast semantics).
+    #[tokio::test]
+    async fn multi_consumer_two_consumers_both_receive_all_items() {
+        let items = vec![10u32, 20, 30];
+        let mut mcs = MultiConsumerStream::new(futures::stream::iter(items.clone()));
+        let r1 = mcs.get();
+        let r2 = mcs.get();
+        mcs.run().await;
+
+        let (c1, c2): (Vec<u32>, Vec<u32>) =
+            futures::future::join(r1.collect(), r2.collect()).await;
+        assert_eq!(c1, items);
+        assert_eq!(c2, items);
+    }
+
+    /// An empty inner stream delivers no items and closes the receiver immediately.
+    #[tokio::test]
+    async fn multi_consumer_empty_stream() {
+        let mut mcs = MultiConsumerStream::new(futures::stream::iter(Vec::<u32>::new()));
+        let receiver = mcs.get();
+        mcs.run().await;
+
+        let collected: Vec<u32> = receiver.collect().await;
+        assert!(collected.is_empty());
+    }
+
+    // ---- RunFutureAsStream ----
+
+    /// RunFutureAsStream always produces zero items: it drives the future to completion
+    /// and then signals end-of-stream without ever yielding an item.
+    #[tokio::test]
+    async fn run_future_as_stream_yields_no_items() {
+        // The future does some work (here a trivial async block) but the stream
+        // surface never surfaces an Item.
+        let fut = Box::pin(async { 42u32 });
+        let stream: RunFutureAsStream<u32, _, _> = RunFutureAsStream::new(fut);
+        let items: Vec<u32> = stream.collect().await;
+        assert!(items.is_empty());
+    }
+
+    /// size_hint always reports (0, None) since no items are ever produced.
+    #[test]
+    fn run_future_as_stream_size_hint() {
+        let fut = Box::pin(async { () });
+        let stream: RunFutureAsStream<u32, _, _> = RunFutureAsStream::new(fut);
+        assert_eq!(stream.size_hint(), (0, None));
+    }
+}


### PR DESCRIPTION
## Coverage gaps addressed

### 1. `MultiConsumerStream` — zero tests → 3 new tests (`marigold-impl/src/multi_consumer_stream.rs`)

**Prior state:** `MultiConsumerStream` and `RunFutureAsStream` had no tests at all. This is a concurrency-sensitive component (broadcast fan-out over async channels) whose correctness is non-obvious.

**New tests:**
- `multi_consumer_single_consumer_receives_all_items` — happy path: one consumer gets every item
- `multi_consumer_two_consumers_both_receive_all_items` — broadcast invariant: two independent consumers both receive all items (the core semantic guarantee of `MultiConsumerStream`)
- `multi_consumer_empty_stream` — edge case: empty inner stream closes receivers cleanly without hanging

**Key invariant validated:** Every registered consumer receives every item exactly once.

### 2. `RunFutureAsStream` — zero tests → 2 new tests (`marigold-impl/src/multi_consumer_stream.rs`)

**Prior state:** `RunFutureAsStream` is used by the generated code for stream variable runners. Its documented behavior ("drives a future to completion; never yields any items") was unverified.

**New tests:**
- `run_future_as_stream_yields_no_items` — confirms the stream produces zero items after the future resolves
- `run_future_as_stream_size_hint` — confirms `size_hint()` always reports `(0, None)`

### 3. `Marifold` / fold adapter — 1 test → 4 tests (`marigold-impl/src/marifold.rs`)

**Prior state:** Only the happy-path sum (0..5 = 10) was tested.

**New tests:**
- `fold_empty_stream_returns_init` — empty stream must yield exactly the initial accumulator
- `fold_single_element` — single-element stream applies the function exactly once
- `fold_always_produces_one_item` — property test over multiple lengths: `marifold` must always emit exactly one item regardless of input length (0, 1, 10, 100)

**Key invariant validated:** `marifold` is a cardinality-1 adapter — output length is always 1.

### 4. `CollectAndAppliable` — 2 tests → 5 tests (`marigold-impl/src/collect_and_apply.rs`)

**Prior state:** Only a basic passthrough and a genawaiter-based generator test existed. Empty stream and transformation behaviors were uncovered.

**New tests:**
- `collect_and_apply_empty_stream` — empty stream delivers `vec![]` to the function
- `collect_and_apply_transform` — the applied function can compute a scalar (sum) from the collected data
- `collect_and_apply_single_element` — single-element stream passes a length-1 vec

### 5. `type_aggregation` — zero tests → 9 new tests (`marigold-grammar/src/type_aggregation.rs`)

**Prior state:** `aggregate_input_variability` and `aggregate_input_count` had no tests at all. These functions determine how the static analyzer combines cardinality information across streams.

**New tests for `aggregate_input_variability`:**
- `variability_all_constant` — all-constant inputs → Constant
- `variability_any_variable_dominates` — any Variable → Variable (dominance rule)
- `variability_single_variable` — single Variable input
- `variability_empty_is_constant` — vacuously true: empty input → Constant

**New tests for `aggregate_input_count`:**
- `count_known_values_are_summed` — Known counts are summed
- `count_unknown_dominates` — any Unknown → Unknown (dominance rule)
- `count_unresolved_enum_returns_unknown` — unresolved Enum variant → Unknown
- `count_empty_is_zero` — empty input → Known(0)
- `count_single_known` — single Known passes through unchanged

**Key invariants validated:** Both aggregation functions respect their dominance rules (Variable > Constant; Unknown > Known), and both handle empty iterators correctly.
