### PR TITLE
[arch/test/clarity] marigold: architecture, test coverage, and clarity improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![lines of code](https://raw.githubusercontent.com/DominicBurkart/marigold/main/development_metadata/badges/lines_of_code.svg)](https://github.com/DominicBurkart/marigold)
 [![contributors](https://raw.githubusercontent.com/DominicBurkart/marigold/main/development_metadata/badges/contributors.svg)](https://github.com/DominicBurkart/marigold/graphs/contributors)
 [![bench](https://github.com/DominicBurkart/marigold/workflows/bench/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/bench.yaml)
-[![codecov](https://codecov.io/gh/DominicBurkart/nanna-coder/graph/badge.svg?token=47S7xzd3Ny)](https://codecov.io/gh/DominicBurkart/nanna-coder)
+[![codecov](https://codecov.io/gh/DominicBurkart/marigold/graph/badge.svg)](https://codecov.io/gh/DominicBurkart/marigold)
 [![tests](https://github.com/DominicBurkart/marigold/workflows/tests/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/tests.yaml)
 [![style](https://github.com/DominicBurkart/marigold/workflows/style/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/style.yaml)
 [![wasm](https://github.com/DominicBurkart/marigold/workflows/wasm/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/wasm.yaml)

--- a/marigold-grammar/src/lib.rs
+++ b/marigold-grammar/src/lib.rs
@@ -18,19 +18,11 @@
 //! Parse a Marigold program:
 //!
 //! ```ignore
-//! use marigold_grammar::parser::parse_marigold;
-//!
-//! let code = parse_marigold("range(0, 100).return")?;
+//! let code = marigold_grammar::marigold_parse("range(0, 100).return")?;
 //! println!("{}", code);
 //! ```
 //!
 //! ## Architecture
-//!
-//! ### Parser
-//!
-//! The [`parser`] module provides the Pest-based parser with a trait abstraction
-//! for extensibility. The factory function [`parser::get_parser()`] returns a
-//! parser instance.
 //!
 //! ### Grammar File
 //!
@@ -75,10 +67,9 @@ mod type_aggregation;
 
 pub mod pest_ast_builder;
 
-/// Convenience function for parsing Marigold code
+/// Convenience function for parsing Marigold code into Rust.
 ///
-/// This is an alias for [`parser::parse_marigold`] that uses the appropriate parser
-/// based on feature flags. It's the recommended entry point for most use cases.
+/// This is the recommended entry point for most use cases.
 ///
 /// # Examples
 ///
@@ -96,13 +87,4 @@ pub fn marigold_analyze(
     s: &str,
 ) -> Result<complexity::ProgramComplexity, parser::MarigoldParseError> {
     parser::PestParser::analyze(s)
-}
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 4);
-    }
 }

--- a/marigold-grammar/src/lib.rs
+++ b/marigold-grammar/src/lib.rs
@@ -18,11 +18,17 @@
 //! Parse a Marigold program:
 //!
 //! ```ignore
-//! let code = marigold_grammar::marigold_parse("range(0, 100).return")?;
+//! let code = marigold_grammar::marigold_parse("range(0, 100).return").unwrap();
 //! println!("{}", code);
 //! ```
 //!
 //! ## Architecture
+//!
+//! ### Parser
+//!
+//! The [`parser`] module provides the Pest-based parser with a trait abstraction
+//! for extensibility. The factory function [`parser::get_parser()`] returns a
+//! parser instance.
 //!
 //! ### Grammar File
 //!
@@ -67,16 +73,15 @@ mod type_aggregation;
 
 pub mod pest_ast_builder;
 
-/// Convenience function for parsing Marigold code into Rust.
+/// Convenience function for parsing Marigold code
 ///
-/// This is the recommended entry point for most use cases.
+/// This is an alias for [`parser::parse_marigold`] that uses the appropriate parser
+/// based on feature flags. It's the recommended entry point for most use cases.
 ///
 /// # Examples
 ///
 /// ```ignore
-/// use marigold_grammar::marigold_parse;
-///
-/// let code = marigold_parse("range(0, 100).return")?;
+/// let code = marigold_grammar::marigold_parse("range(0, 100).return").unwrap();
 /// // code is now valid Rust code ready to compile
 /// ```
 pub fn marigold_parse(s: &str) -> Result<String, parser::MarigoldParseError> {

--- a/marigold-grammar/src/type_aggregation.rs
+++ b/marigold-grammar/src/type_aggregation.rs
@@ -26,3 +26,89 @@ pub fn aggregate_input_count<I: IntoIterator<Item = nodes::InputCount>>(
     }
     nodes::InputCount::Known(total_count)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::nodes::{InputCount, InputVariability};
+    use num_bigint::BigUint;
+
+    // --- aggregate_input_variability ---
+
+    #[test]
+    fn variability_all_constant_is_constant() {
+        let result = aggregate_input_variability(vec![
+            InputVariability::Constant,
+            InputVariability::Constant,
+        ]);
+        assert_eq!(result, InputVariability::Constant);
+    }
+
+    #[test]
+    fn variability_any_variable_is_variable() {
+        let result = aggregate_input_variability(vec![
+            InputVariability::Constant,
+            InputVariability::Variable,
+            InputVariability::Constant,
+        ]);
+        assert_eq!(result, InputVariability::Variable);
+    }
+
+    #[test]
+    fn variability_all_variable_is_variable() {
+        let result = aggregate_input_variability(vec![
+            InputVariability::Variable,
+            InputVariability::Variable,
+        ]);
+        assert_eq!(result, InputVariability::Variable);
+    }
+
+    #[test]
+    fn variability_empty_iter_is_constant() {
+        // No variabilities to aggregate => nothing is variable => Constant.
+        let result = aggregate_input_variability(std::iter::empty());
+        assert_eq!(result, InputVariability::Constant);
+    }
+
+    // --- aggregate_input_count ---
+
+    #[test]
+    fn count_sums_known_values() {
+        let result = aggregate_input_count(vec![
+            InputCount::Known(BigUint::from(3u32)),
+            InputCount::Known(BigUint::from(7u32)),
+        ]);
+        assert_eq!(result, InputCount::Known(BigUint::from(10u32)));
+    }
+
+    #[test]
+    fn count_empty_iter_is_zero() {
+        let result = aggregate_input_count(std::iter::empty::<InputCount>());
+        assert_eq!(result, InputCount::Known(BigUint::from(0u32)));
+    }
+
+    #[test]
+    fn count_unknown_short_circuits() {
+        let result = aggregate_input_count(vec![
+            InputCount::Known(BigUint::from(5u32)),
+            InputCount::Unknown,
+            InputCount::Known(BigUint::from(3u32)),
+        ]);
+        assert_eq!(result, InputCount::Unknown);
+    }
+
+    #[test]
+    fn count_enum_short_circuits() {
+        let result = aggregate_input_count(vec![
+            InputCount::Known(BigUint::from(2u32)),
+            InputCount::Enum("MyEnum".to_string()),
+        ]);
+        assert_eq!(result, InputCount::Unknown);
+    }
+
+    #[test]
+    fn count_single_known_value() {
+        let result = aggregate_input_count(vec![InputCount::Known(BigUint::from(42u32))]);
+        assert_eq!(result, InputCount::Known(BigUint::from(42u32)));
+    }
+}

--- a/marigold-impl/src/async_runtime.rs
+++ b/marigold-impl/src/async_runtime.rs
@@ -1,4 +1,6 @@
-#[cfg(all(feature = "tokio", not(feature = "async-std")))]
+// When tokio is enabled (with or without async-std), use tokio::spawn.
+// async-std alone uses async_std::task::spawn.
+#[cfg(feature = "tokio")]
 pub fn spawn<T>(future: T) -> tokio::task::JoinHandle<T::Output>
 where
     T: std::future::Future + Send + 'static,
@@ -14,14 +16,4 @@ where
     T::Output: Send + 'static,
 {
     async_std::task::spawn(future)
-}
-
-// When both features are enabled, tokio takes precedence
-#[cfg(all(feature = "tokio", feature = "async-std"))]
-pub fn spawn<T>(future: T) -> tokio::task::JoinHandle<T::Output>
-where
-    T: std::future::Future + Send + 'static,
-    T::Output: Send + 'static,
-{
-    tokio::spawn(future)
 }

--- a/marigold-impl/src/collect_and_apply.rs
+++ b/marigold-impl/src/collect_and_apply.rs
@@ -39,7 +39,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn permutations_with_replacement() {
+    async fn collect_and_apply_empty_stream() {
+        let result: Vec<i32> = futures::stream::iter(std::iter::empty::<i32>())
+            .collect_and_apply(|x| x)
+            .await;
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn collect_and_apply_transformation() {
+        // Verify the collected vector is passed verbatim to the function.
+        let sum: i32 = futures::stream::iter(vec![1i32, 2, 3, 4])
+            .collect_and_apply(|v| v.iter().sum())
+            .await;
+        assert_eq!(sum, 10);
+    }
+
+    #[tokio::test]
+    async fn collect_and_apply_with_nested_async() {
         use futures::StreamExt;
         use genawaiter;
 

--- a/marigold-impl/src/marifold.rs
+++ b/marigold-impl/src/marifold.rs
@@ -15,6 +15,11 @@ pub trait Marifold<SInput, State, F, Fut> {
 
 /// This is an adapter trait that allows fold from StreamExt to return a Stream
 /// with a single value (the state after the parent stream has been exhausted).
+///
+/// The name `marifold` is a portmanteau of "marigold" and "fold": it wraps
+/// [`futures::StreamExt::fold`] so that the result is itself a single-item
+/// stream rather than a bare future, keeping it composable with other stream
+/// operations in a Marigold pipeline.
 #[async_trait]
 impl<State, SInput, T, F, Fut> Marifold<SInput, State, F, Fut> for SInput
 where
@@ -49,5 +54,38 @@ mod tests {
                 .await,
             vec![10]
         );
+    }
+
+    #[tokio::test]
+    async fn fold_empty_stream() {
+        // An empty stream should yield exactly one item: the initial state.
+        let result: Vec<u32> = futures::stream::iter(std::iter::empty::<u32>())
+            .marifold(42u32, |acc, x| async move { acc + x })
+            .await
+            .collect()
+            .await;
+        assert_eq!(result, vec![42]);
+    }
+
+    #[tokio::test]
+    async fn fold_non_zero_init() {
+        // Verify that the initial state is respected.
+        let result: Vec<i32> = futures::stream::iter(1..=3)
+            .marifold(100i32, |acc, x| async move { acc + x })
+            .await
+            .collect()
+            .await;
+        // 100 + 1 + 2 + 3 = 106
+        assert_eq!(result, vec![106]);
+    }
+
+    #[tokio::test]
+    async fn fold_single_item() {
+        let result: Vec<i32> = futures::stream::iter(std::iter::once(7i32))
+            .marifold(0i32, |acc, x| async move { acc + x })
+            .await
+            .collect()
+            .await;
+        assert_eq!(result, vec![7]);
     }
 }

--- a/marigold-impl/src/multi_consumer_stream.rs
+++ b/marigold-impl/src/multi_consumer_stream.rs
@@ -100,3 +100,40 @@ impl<T: std::marker::Send + Unpin + 'static, O, F: Future<Output = O>> Stream
         (0, None)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream::StreamExt;
+
+    /// A MultiConsumerStream with a single consumer should forward every item.
+    #[tokio::test]
+    async fn single_consumer_receives_all_items() {
+        let source = futures::stream::iter(vec![1u32, 2, 3]);
+        let mut mcs = MultiConsumerStream::new(source);
+        let receiver = mcs.get();
+        mcs.run().await;
+        let items: Vec<u32> = receiver.collect().await;
+        assert_eq!(items, vec![1, 2, 3]);
+    }
+
+    /// An empty source stream should close the receiver immediately.
+    #[tokio::test]
+    async fn empty_source_closes_receiver() {
+        let source = futures::stream::iter(Vec::<u32>::new());
+        let mut mcs = MultiConsumerStream::new(source);
+        let receiver = mcs.get();
+        mcs.run().await;
+        let items: Vec<u32> = receiver.collect().await;
+        assert!(items.is_empty());
+    }
+
+    /// RunFutureAsStream should produce no items and terminate after the future resolves.
+    #[tokio::test]
+    async fn run_future_as_stream_yields_no_items() {
+        let fut = Box::pin(async { () });
+        let stream: RunFutureAsStream<u32, (), _> = RunFutureAsStream::new(fut);
+        let items: Vec<u32> = stream.collect().await;
+        assert!(items.is_empty());
+    }
+}

--- a/marigold-impl/src/multi_consumer_stream.rs
+++ b/marigold-impl/src/multi_consumer_stream.rs
@@ -112,8 +112,9 @@ mod tests {
         let source = futures::stream::iter(vec![1u32, 2, 3]);
         let mut mcs = MultiConsumerStream::new(source);
         let receiver = mcs.get();
-        mcs.run().await;
-        let items: Vec<u32> = receiver.collect().await;
+        // The channel buffer is 1, so the feeder in `run` and the consumer
+        // must make progress concurrently; drive them together.
+        let (_, items) = futures::future::join(mcs.run(), receiver.collect::<Vec<u32>>()).await;
         assert_eq!(items, vec![1, 2, 3]);
     }
 
@@ -123,8 +124,7 @@ mod tests {
         let source = futures::stream::iter(Vec::<u32>::new());
         let mut mcs = MultiConsumerStream::new(source);
         let receiver = mcs.get();
-        mcs.run().await;
-        let items: Vec<u32> = receiver.collect().await;
+        let (_, items) = futures::future::join(mcs.run(), receiver.collect::<Vec<u32>>()).await;
         assert!(items.is_empty());
     }
 

--- a/marigold-impl/src/run_stream.rs
+++ b/marigold-impl/src/run_stream.rs
@@ -40,12 +40,20 @@ mod tests {
     use futures::stream::StreamExt;
 
     #[tokio::test]
-    async fn combinations() {
+    async fn passthrough() {
         assert_eq!(
             run_stream(futures::stream::iter(0_u32..3_u32))
                 .collect::<Vec<_>>()
                 .await,
             vec![0_u32, 1_u32, 2_u32]
         );
+    }
+
+    #[tokio::test]
+    async fn passthrough_empty() {
+        let result: Vec<u32> = run_stream(futures::stream::iter(std::iter::empty::<u32>()))
+            .collect::<Vec<_>>()
+            .await;
+        assert!(result.is_empty());
     }
 }

--- a/marigold/README.md
+++ b/marigold/README.md
@@ -6,7 +6,7 @@
 [![lines of code](https://raw.githubusercontent.com/DominicBurkart/marigold/main/development_metadata/badges/lines_of_code.svg)](https://github.com/DominicBurkart/marigold)
 [![contributors](https://raw.githubusercontent.com/DominicBurkart/marigold/main/development_metadata/badges/contributors.svg)](https://github.com/DominicBurkart/marigold/graphs/contributors)
 [![bench](https://github.com/DominicBurkart/marigold/workflows/bench/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/bench.yaml)
-[![codecov](https://codecov.io/gh/DominicBurkart/nanna-coder/graph/badge.svg?token=47S7xzd3Ny)](https://codecov.io/gh/DominicBurkart/nanna-coder)
+[![codecov](https://codecov.io/gh/DominicBurkart/marigold/graph/badge.svg)](https://codecov.io/gh/DominicBurkart/marigold)
 [![tests](https://github.com/DominicBurkart/marigold/workflows/tests/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/tests.yaml)
 [![style](https://github.com/DominicBurkart/marigold/workflows/style/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/style.yaml)
 [![wasm](https://github.com/DominicBurkart/marigold/workflows/wasm/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/wasm.yaml)


### PR DESCRIPTION
Three focused improvement areas in a single branch. Each commit is independently reviewable.

---

## [arch] Remove duplicate `spawn` impl and placeholder test

**`marigold-impl/src/async_runtime.rs`**: The file had three `spawn()` definitions — one for tokio-only, one for async-std-only, and one for "both features enabled". The both-enabled arm was byte-for-byte identical to the tokio-only arm. Merged them by changing the tokio arm's cfg predicate to `#[cfg(feature = "tokio")]`, which covers both scenarios (tokio takes precedence when both are active). Removes ~10 lines of duplication.

**`marigold-grammar/src/lib.rs`**: Removed the `it_works` placeholder test (`assert_eq!(2 + 2, 4)`) — it was scaffolding with zero coverage value.

---

## [test] Add unit tests for undertested modules

- **`marifold.rs`**: Added `fold_empty_stream` (empty input yields the initial state), `fold_non_zero_init` (verifies `init` is respected), `fold_single_item`.
- **`type_aggregation.rs`**: Full coverage for `aggregate_input_variability` and `aggregate_input_count` — previously had **zero** tests.
- **`multi_consumer_stream.rs`**: Added `single_consumer_receives_all_items`, `empty_source_closes_receiver`, `run_future_as_stream_yields_no_items` — previously had **zero** tests.
- **`collect_and_apply.rs`**: Added `collect_and_apply_empty_stream` and `collect_and_apply_transformation`.
- **`run_stream.rs`**: Added `passthrough_empty`; renamed the existing test from `combinations` → `passthrough` (see clarity section).

---

## [clarity] Fix badge URL, doc examples, and misleading test names

- **`README.md`**: The codecov badge pointed to `DominicBurkart/nanna-coder` instead of `DominicBurkart/marigold`. Fixed.
- **`marigold-grammar/src/lib.rs`**: The Quick Start doc example called `parser::parse_marigold` via a `use` import that doesn't reflect the public API; updated to use the correct top-level path `marigold_grammar::marigold_parse`.
- **`marifold.rs`**: Added a doc comment explaining the "marifold" name (portmanteau of "marigold" and "fold").
- **`run_stream.rs`**: Test `combinations` renamed to `passthrough` — it tested basic stream passthrough, not the `combinations` operation.
- **`collect_and_apply.rs`**: Test `permutations_with_replacement` renamed to `collect_and_apply_with_nested_async` — it was testing `collect_and_apply` with a nested generator closure, not permutations.

---

## Test plan

- [ ] `cargo test -p marigold-impl --features tokio` — all existing and new tests pass
- [ ] `cargo test -p marigold-impl --features tokio,async-std` — spawn still resolves to tokio
- [ ] `cargo test -p marigold-grammar` — type_aggregation tests and other grammar tests pass
- [ ] Verify codecov badge now loads correctly in README preview