### PR TITLE
fix(ci): Rust 1.95.0 compatibility on main (clippy + trybuild)

### DIFF
--- a/examples/bounded-types/compile_fail/min_greater_than_max.stderr
+++ b/examples/bounded-types/compile_fail/min_greater_than_max.stderr
@@ -10,14 +10,3 @@ error: proc macro panicked
    | |_____^
    |
    = help: message: marigold parsing error: MarigoldParseError("Bounded type validation failed:\n  - Bounds violation for field 'Sensor.reading': min (100) is greater than max (0)")
-
-error[E0282]: type annotations needed
-  --> compile_fail/min_greater_than_max.rs:6:13
-   |
- 6 |       let _ = m!(
-   |  _____________^
- 7 | |         struct Sensor {
- 8 | |             reading: int[100, 0]
-...  |
-12 | |     .await
-   | |__________^ cannot infer type

--- a/examples/bounded-types/compile_fail/negative_bounds_uint.stderr
+++ b/examples/bounded-types/compile_fail/negative_bounds_uint.stderr
@@ -10,14 +10,3 @@ error: proc macro panicked
    | |_____^
    |
    = help: message: marigold parsing error: MarigoldParseError("Bounded type validation failed:\n  - Bounds violation for field 'Temp.reading': uint[] cannot have negative min value (-10)")
-
-error[E0282]: type annotations needed
-  --> compile_fail/negative_bounds_uint.rs:6:13
-   |
- 6 |       let _ = m!(
-   |  _____________^
- 7 | |         struct Temp {
- 8 | |             reading: uint[-10, -1]
-...  |
-12 | |     .await
-   | |__________^ cannot infer type

--- a/examples/bounded-types/compile_fail/negative_min_uint.stderr
+++ b/examples/bounded-types/compile_fail/negative_min_uint.stderr
@@ -10,14 +10,3 @@ error: proc macro panicked
    | |_____^
    |
    = help: message: marigold parsing error: MarigoldParseError("Bounded type validation failed:\n  - Bounds violation for field 'Sensor.reading': uint[] cannot have negative min value (-1)")
-
-error[E0282]: type annotations needed
-  --> compile_fail/negative_min_uint.rs:6:13
-   |
- 6 |       let _ = m!(
-   |  _____________^
- 7 | |         struct Sensor {
- 8 | |             reading: uint[-1, 10]
-...  |
-12 | |     .await
-   | |__________^ cannot infer type

--- a/examples/bounded-types/compile_fail/undefined_type_reference.stderr
+++ b/examples/bounded-types/compile_fail/undefined_type_reference.stderr
@@ -10,14 +10,3 @@ error: proc macro panicked
    | |_____^
    |
    = help: message: marigold parsing error: MarigoldParseError("Bounded type validation failed:\n  - Undefined type: 'NonExistent'")
-
-error[E0282]: type annotations needed
-  --> compile_fail/undefined_type_reference.rs:6:13
-   |
- 6 |       let _ = m!(
-   |  _____________^
- 7 | |         struct Sensor {
- 8 | |             reading: int[0, NonExistent.len()]
-...  |
-12 | |     .await
-   | |__________^ cannot infer type

--- a/marigold-impl/src/keep_first_n.rs
+++ b/marigold-impl/src/keep_first_n.rs
@@ -97,8 +97,7 @@ where
                 .into_sorted_vec()
                 .into_iter()
                 .map(|(_idx, item)| item) // Unwrap indices
-                .collect::<Vec<_>>()
-                .into_iter(),
+                .collect::<Vec<_>>(),
         );
     }
 
@@ -173,8 +172,7 @@ where
             .into_sorted_vec()
             .into_iter()
             .map(|(_idx, item)| item) // Unwrap indices
-            .collect::<Vec<_>>()
-            .into_iter(),
+            .collect::<Vec<_>>(),
     )
 }
 


### PR DESCRIPTION
## Summary

Restores CI on main after Rust 1.95.0 (released 2026-04-14) became the `stable` toolchain.

Cherry-picked from PR #182 (`7fd998d`) so the fix lands without waiting on the coverage work.

- `clippy::useless_conversion` now flags `.into_iter()` on values passed to `futures::stream::iter` (accepts `IntoIterator`). Removed the two redundant `.into_iter()` calls in `marigold-impl/src/keep_first_n.rs` that were breaking the `style hooks` job.
- `trybuild` snapshots in `examples/bounded-types/compile_fail/*.stderr` expected an `error[E0282]: type annotations needed` block that rustc 1.95.0 no longer emits (improved inference after proc-macro panic). Regenerated all four via `TRYBUILD=overwrite`, unblocking the `Tests` job.

## Not included

`Benches` is still red on main — that's the long-standing duplicate `c.bench_function` id issue that PR #175 explicitly fixes. Leaving it untouched here to avoid stepping on #175.

## Test plan

- [x] Verified on PR #182: `Tests` ✅ (12m 37s), `style hooks` ✅ (4m 35s), all 11 other checks ✅
- [ ] CI green on this PR