### PR TITLE
chore: align README badges and dedupe async_runtime spawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![lines of code](https://raw.githubusercontent.com/DominicBurkart/marigold/main/development_metadata/badges/lines_of_code.svg)](https://github.com/DominicBurkart/marigold)
 [![contributors](https://raw.githubusercontent.com/DominicBurkart/marigold/main/development_metadata/badges/contributors.svg)](https://github.com/DominicBurkart/marigold/graphs/contributors)
 [![bench](https://github.com/DominicBurkart/marigold/workflows/bench/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/bench.yaml)
-[![codecov](https://codecov.io/gh/DominicBurkart/nanna-coder/graph/badge.svg?token=47S7xzd3Ny)](https://codecov.io/gh/DominicBurkart/nanna-coder)
+[![codecov](https://codecov.io/gh/DominicBurkart/marigold/graph/badge.svg)](https://codecov.io/gh/DominicBurkart/marigold)
 [![tests](https://github.com/DominicBurkart/marigold/workflows/tests/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/tests.yaml)
 [![style](https://github.com/DominicBurkart/marigold/workflows/style/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/style.yaml)
 [![wasm](https://github.com/DominicBurkart/marigold/workflows/wasm/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/wasm.yaml)

--- a/marigold-impl/src/async_runtime.rs
+++ b/marigold-impl/src/async_runtime.rs
@@ -1,4 +1,7 @@
-#[cfg(all(feature = "tokio", not(feature = "async-std")))]
+// When the `tokio` feature is enabled it takes precedence over `async-std`,
+// so a single definition covers both the tokio-only and the
+// tokio + async-std cases.
+#[cfg(feature = "tokio")]
 pub fn spawn<T>(future: T) -> tokio::task::JoinHandle<T::Output>
 where
     T: std::future::Future + Send + 'static,
@@ -14,14 +17,4 @@ where
     T::Output: Send + 'static,
 {
     async_std::task::spawn(future)
-}
-
-// When both features are enabled, tokio takes precedence
-#[cfg(all(feature = "tokio", feature = "async-std"))]
-pub fn spawn<T>(future: T) -> tokio::task::JoinHandle<T::Output>
-where
-    T: std::future::Future + Send + 'static,
-    T::Output: Send + 'static,
-{
-    tokio::spawn(future)
 }

--- a/marigold/README.md
+++ b/marigold/README.md
@@ -6,7 +6,7 @@
 [![lines of code](https://raw.githubusercontent.com/DominicBurkart/marigold/main/development_metadata/badges/lines_of_code.svg)](https://github.com/DominicBurkart/marigold)
 [![contributors](https://raw.githubusercontent.com/DominicBurkart/marigold/main/development_metadata/badges/contributors.svg)](https://github.com/DominicBurkart/marigold/graphs/contributors)
 [![bench](https://github.com/DominicBurkart/marigold/workflows/bench/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/bench.yaml)
-[![codecov](https://codecov.io/gh/DominicBurkart/nanna-coder/graph/badge.svg?token=47S7xzd3Ny)](https://codecov.io/gh/DominicBurkart/nanna-coder)
+[![codecov](https://codecov.io/gh/DominicBurkart/marigold/graph/badge.svg)](https://codecov.io/gh/DominicBurkart/marigold)
 [![tests](https://github.com/DominicBurkart/marigold/workflows/tests/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/tests.yaml)
 [![style](https://github.com/DominicBurkart/marigold/workflows/style/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/style.yaml)
 [![wasm](https://github.com/DominicBurkart/marigold/workflows/wasm/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/wasm.yaml)


### PR DESCRIPTION
Automated improvement PR — please review before merging.

Surgical alignment and redundancy reductions. No behavior changes.

## Changes

### 1. Fix codecov badge repo in both READMEs
The codecov badge in `README.md` and `marigold/README.md` pointed at
`DominicBurkart/nanna-coder` (including a hard-coded token), not this
repository. That is a doc-vs-reality misalignment: the badge URL does
not describe the marigold project. Repointed to
`DominicBurkart/marigold` and dropped the stale token query arg.

### 2. Dedupe `spawn` definitions in `marigold-impl/src/async_runtime.rs`
The file had three `cfg` branches. The `feature = "tokio"` branch and
the `feature = "tokio", feature = "async-std"` branch contained
byte-identical bodies and signatures — the second existed only to
encode the "tokio takes precedence" rule. Collapsing them into a
single `cfg(feature = "tokio")` definition preserves that precedence
(because the remaining async-std branch is gated on
`not(feature = "tokio")`) while removing a redundant function body and
~10 LOC. No behavior change: every feature combination still resolves
to exactly one `spawn` with the same return type as before.
