### PR TITLE
docs: clarity and consistency pass on README and crate docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@
 [![lines of code](https://raw.githubusercontent.com/DominicBurkart/marigold/main/development_metadata/badges/lines_of_code.svg)](https://github.com/DominicBurkart/marigold)
 [![contributors](https://raw.githubusercontent.com/DominicBurkart/marigold/main/development_metadata/badges/contributors.svg)](https://github.com/DominicBurkart/marigold/graphs/contributors)
 [![bench](https://github.com/DominicBurkart/marigold/workflows/bench/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/bench.yaml)
-[![codecov](https://codecov.io/gh/DominicBurkart/nanna-coder/graph/badge.svg?token=47S7xzd3Ny)](https://codecov.io/gh/DominicBurkart/nanna-coder)
+[![codecov](https://codecov.io/gh/DominicBurkart/marigold/graph/badge.svg)](https://codecov.io/gh/DominicBurkart/marigold)
 [![tests](https://github.com/DominicBurkart/marigold/workflows/tests/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/tests.yaml)
 [![style](https://github.com/DominicBurkart/marigold/workflows/style/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/style.yaml)
 [![wasm](https://github.com/DominicBurkart/marigold/workflows/wasm/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/wasm.yaml)
 [![last commit](https://img.shields.io/github/last-commit/dominicburkart/marigold)](https://github.com/DominicBurkart/marigold)
 
 Marigold is an imperative, domain-specific language for data pipelining and
-analysis using async streams. It can be used as a standalone language or within
-Rust programs.
+analysis over async streams. It can be used as a standalone language or
+embedded in Rust programs via a macro.
 
 ```rust
 use marigold::m;
@@ -36,17 +36,19 @@ println!("{:?}", odd_digits); // [1, 3, 5, 7, 9]
 
 ### Install
 
+Via the install script:
+
 ```sh
 curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/DominicBurkart/marigold/main/install.sh | sh
 ```
 
-Or via cargo:
+Via cargo:
 
 ```sh
 cargo install marigold -F cli
 ```
 
-Or from source:
+From source:
 
 ```sh
 git clone https://github.com/DominicBurkart/marigold.git
@@ -54,7 +56,7 @@ cd marigold
 cargo install --path marigold -F cli
 ```
 
-### Hello World
+### Hello world
 
 Create `hello_world.marigold`:
 
@@ -78,9 +80,9 @@ Output:
 4
 ```
 
-### Static Analysis
+### Static analysis
 
-Marigold can statically analyze your program's complexity:
+Marigold can statically analyze a program's complexity:
 
 ```sh
 marigold analyze hello_world.marigold
@@ -109,14 +111,13 @@ marigold analyze hello_world.marigold
 
 ## Runtimes
 
-By default, Marigold works in a single future and can work with any runtime.
+By default, Marigold runs inside a single future and works with any async
+runtime. Enabling the `tokio` or `async-std` feature lets Marigold spawn
+additional tasks so pipelines can run in parallel on multithreaded runtimes.
 
-The `tokio` and `async-std` features allow Marigold to spawn additional tasks,
-enabling parallelism for multithreaded runtimes.
-
-Marigold supports async tracing, e.g. with tokio-console.
+Async tracing is supported (for example, via `tokio-console`).
 
 ## Platforms
 
-Marigold's CI builds against aarch64, arm, WASM, and x86 targets, and builds
-the x86 target in mac and windows environments.
+CI builds Marigold for aarch64, arm, WASM, and x86 targets, and additionally
+builds the x86 target on macOS and Windows.

--- a/marigold-grammar/src/lib.rs
+++ b/marigold-grammar/src/lib.rs
@@ -1,66 +1,50 @@
 #![forbid(unsafe_code)]
 
-//! # Marigold Grammar Library
+//! # marigold-grammar
 //!
-//! This crate provides the grammar and parser infrastructure for the Marigold DSL.
+//! Grammar, parser, and code generation for the Marigold DSL. This crate is
+//! used by `marigold-macros` (and in turn the `marigold` crate); most users
+//! should depend on `marigold` instead of consuming this crate directly.
 //!
-//! ## Overview
+//! ## What it provides
 //!
-//! Marigold is a domain-specific language for expressing stream processing programs in Rust.
-//! This library provides:
+//! - A Pest-based PEG parser for Marigold source (`src/marigold.pest`).
+//! - AST definitions for all Marigold constructs ([`nodes`]).
+//! - A transformer from Pest parse trees to the AST ([`pest_ast_builder`]).
+//! - Code generation that lowers Marigold programs to Rust source.
+//! - Static complexity analysis ([`complexity`]).
 //!
-//! - **Pest-based parser**: Fast, maintainable PEG parser
-//! - **AST definitions**: Complete abstract syntax tree for Marigold programs
-//! - **Code generation**: Transforms Marigold programs into valid Rust code
+//! ## Quick start
 //!
-//! ## Quick Start
-//!
-//! Parse a Marigold program:
+//! Parse a Marigold program into equivalent Rust source:
 //!
 //! ```ignore
-//! use marigold_grammar::parser::parse_marigold;
+//! use marigold_grammar::marigold_parse;
 //!
-//! let code = parse_marigold("range(0, 100).return")?;
-//! println!("{}", code);
+//! let rust_src = marigold_parse("range(0, 100).return")?;
+//! // `rust_src` is Rust code ready to be compiled.
 //! ```
 //!
-//! ## Architecture
+//! ## Modules
 //!
-//! ### Parser
+//! - [`parser`]: Pest-based parser; [`parser::get_parser`] returns a parser
+//!   instance, and [`parser::parse_marigold`] is the main entry point.
+//! - [`nodes`]: AST node definitions.
+//! - [`pest_ast_builder`]: Pest parse tree -> AST.
+//! - [`complexity`]: Static complexity analysis.
+//! - [`bound_resolution`], [`symbol_table`]: Name and bound resolution.
 //!
-//! The [`parser`] module provides the Pest-based parser with a trait abstraction
-//! for extensibility. The factory function [`parser::get_parser()`] returns a
-//! parser instance.
+//! ## Testing
 //!
-//! ### Grammar File
+//! The parser is covered by unit tests in each module, negative tests for
+//! invalid syntax, and integration tests that parse the example programs in
+//! the workspace.
 //!
-//! - **Pest**: `src/marigold.pest` - Defines the complete Marigold language grammar
+//! ## Feature flags
 //!
-//! ### AST and Code Generation
-//!
-//! - [`nodes`]: AST node definitions for all Marigold constructs
-//! - Code generation: Internal function that transforms AST to Rust code
-//! - [`pest_ast_builder`]: Transforms Pest parse trees into the AST
-//!
-//! ## Testing & Validation
-//!
-//! The parser implementation is validated through:
-//!
-//! - **Unit tests** in each module covering specific functionality
-//! - **Negative tests** ensuring invalid syntax is properly rejected
-//! - **Integration tests** using real-world example programs
-//!
-//! ## Feature Flags
-//!
-//! - `io`: I/O features (available in other crates)
-//! - `tokio`: Tokio runtime integration (available in other crates)
-//! - `async-std`: async-std runtime integration (available in other crates)
-//!
-//! ## Performance Characteristics
-//!
-//! - **Parsing**: Completes in < 1ms for typical programs
-//! - **Code generation**: Dominates runtime, scales with program complexity
-//! - **Binary size**: Pest parser adds ~40KB to binary size
+//! This crate has no feature flags of its own. Runtime (`tokio`, `async-std`)
+//! and I/O (`io`) features are exposed by the top-level `marigold` crate and
+//! by `marigold-impl`.
 
 extern crate proc_macro;
 
@@ -75,23 +59,24 @@ mod type_aggregation;
 
 pub mod pest_ast_builder;
 
-/// Convenience function for parsing Marigold code
+/// Parse Marigold source into equivalent Rust source.
 ///
-/// This is an alias for [`parser::parse_marigold`] that uses the appropriate parser
-/// based on feature flags. It's the recommended entry point for most use cases.
+/// This is a convenience wrapper around [`parser::parse_marigold`] and is the
+/// recommended entry point for most use cases.
 ///
 /// # Examples
 ///
 /// ```ignore
 /// use marigold_grammar::marigold_parse;
 ///
-/// let code = marigold_parse("range(0, 100).return")?;
-/// // code is now valid Rust code ready to compile
+/// let rust_src = marigold_parse("range(0, 100).return")?;
+/// // `rust_src` is Rust code ready to be compiled.
 /// ```
 pub fn marigold_parse(s: &str) -> Result<String, parser::MarigoldParseError> {
     parser::parse_marigold(s)
 }
 
+/// Statically analyze the complexity of a Marigold program.
 pub fn marigold_analyze(
     s: &str,
 ) -> Result<complexity::ProgramComplexity, parser::MarigoldParseError> {

--- a/marigold/README.md
+++ b/marigold/README.md
@@ -6,15 +6,15 @@
 [![lines of code](https://raw.githubusercontent.com/DominicBurkart/marigold/main/development_metadata/badges/lines_of_code.svg)](https://github.com/DominicBurkart/marigold)
 [![contributors](https://raw.githubusercontent.com/DominicBurkart/marigold/main/development_metadata/badges/contributors.svg)](https://github.com/DominicBurkart/marigold/graphs/contributors)
 [![bench](https://github.com/DominicBurkart/marigold/workflows/bench/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/bench.yaml)
-[![codecov](https://codecov.io/gh/DominicBurkart/nanna-coder/graph/badge.svg?token=47S7xzd3Ny)](https://codecov.io/gh/DominicBurkart/nanna-coder)
+[![codecov](https://codecov.io/gh/DominicBurkart/marigold/graph/badge.svg)](https://codecov.io/gh/DominicBurkart/marigold)
 [![tests](https://github.com/DominicBurkart/marigold/workflows/tests/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/tests.yaml)
 [![style](https://github.com/DominicBurkart/marigold/workflows/style/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/style.yaml)
 [![wasm](https://github.com/DominicBurkart/marigold/workflows/wasm/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/wasm.yaml)
 [![last commit](https://img.shields.io/github/last-commit/dominicburkart/marigold)](https://github.com/DominicBurkart/marigold)
 
 Marigold is an imperative, domain-specific language for data pipelining and
-analysis using async streams. It can be used as a standalone language or within
-Rust programs.
+analysis over async streams. It can be used as a standalone language or
+embedded in Rust programs via a macro.
 
 ```rust
 use marigold::m;
@@ -36,17 +36,19 @@ println!("{:?}", odd_digits); // [1, 3, 5, 7, 9]
 
 ### Install
 
+Via the install script:
+
 ```sh
 curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/DominicBurkart/marigold/main/install.sh | sh
 ```
 
-Or via cargo:
+Via cargo:
 
 ```sh
 cargo install marigold -F cli
 ```
 
-Or from source:
+From source:
 
 ```sh
 git clone https://github.com/DominicBurkart/marigold.git
@@ -54,7 +56,7 @@ cd marigold
 cargo install --path marigold -F cli
 ```
 
-### Hello World
+### Hello world
 
 Create `hello_world.marigold`:
 
@@ -78,9 +80,9 @@ Output:
 4
 ```
 
-### Static Analysis
+### Static analysis
 
-Marigold can statically analyze your program's complexity:
+Marigold can statically analyze a program's complexity:
 
 ```sh
 marigold analyze hello_world.marigold
@@ -109,14 +111,13 @@ marigold analyze hello_world.marigold
 
 ## Runtimes
 
-By default, Marigold works in a single future and can work with any runtime.
+By default, Marigold runs inside a single future and works with any async
+runtime. Enabling the `tokio` or `async-std` feature lets Marigold spawn
+additional tasks so pipelines can run in parallel on multithreaded runtimes.
 
-The `tokio` and `async-std` features allow Marigold to spawn additional tasks,
-enabling parallelism for multithreaded runtimes.
-
-Marigold supports async tracing, e.g. with tokio-console.
+Async tracing is supported (for example, via `tokio-console`).
 
 ## Platforms
 
-Marigold's CI builds against aarch64, arm, WASM, and x86 targets, and builds
-the x86 target in mac and windows environments.
+CI builds Marigold for aarch64, arm, WASM, and x86 targets, and additionally
+builds the x86 target on macOS and Windows.

--- a/marigold/src/lib.rs
+++ b/marigold/src/lib.rs
@@ -1,7 +1,8 @@
-//! Marigold is a domain specific language for data pipelining and analysis. It compiles to
-//! asynchronous Rust and can be integrated into Rust programs using a macro.
+//! Marigold is an imperative, domain-specific language for data pipelining
+//! and analysis over async streams. It compiles to asynchronous Rust and can
+//! be embedded in Rust programs via the [`m!`] macro.
 //!
-//! ## Example Usage
+//! # Example
 //!
 //! ```rust
 //! # #[tokio::main]
@@ -24,7 +25,8 @@
 //! ```
 #![forbid(unsafe_code)]
 
-pub use crate as marigold; // used so that the tests can reference re-exported values
+// Re-exported so tests and macro output can reference this crate by name.
+pub use crate as marigold;
 pub use marigold_impl;
 
 pub use marigold_macros::marigold as m;


### PR DESCRIPTION
Automated clarity PR — please review.

## Changes

- `README.md` and `marigold/README.md` (kept in sync):
  - Fix codecov badge that was pointing at the `nanna-coder` repo instead of `marigold`.
  - Standardize section headings (sentence case) and tone; tighten prose.
  - Replace "Or via cargo" / "Or from source" with a consistent labeled-list style.
  - Reword the runtimes section for precision (single future by default; `tokio`/`async-std` enable task spawning).
- `marigold/src/lib.rs`:
  - Align crate-level summary with the README so both describe Marigold the same way.
  - Link to the `m!` macro and drop a redundant comment.
- `marigold-grammar/src/lib.rs`:
  - Deduplicate the overview (no longer repeats "Marigold is a DSL..." already in the top-level crate).
  - Clarify that this crate is typically consumed via `marigold` / `marigold-macros`.
  - Remove unverified performance claims ("< 1ms", "~40KB binary size") and the misleading feature-flags section (those flags live on sibling crates, not here).
  - Add brief module map and a doc comment for `marigold_analyze`.
  - Rewrite the Quick start snippet so the returned Rust source is named, not discarded.

No code behavior changes; documentation only.
