### PR TITLE
test(grammar): pin aggregator invariants + codecov badge fix + CLI dispatch cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![lines of code](https://raw.githubusercontent.com/DominicBurkart/marigold/main/development_metadata/badges/lines_of_code.svg)](https://github.com/DominicBurkart/marigold)
 [![contributors](https://raw.githubusercontent.com/DominicBurkart/marigold/main/development_metadata/badges/contributors.svg)](https://github.com/DominicBurkart/marigold/graphs/contributors)
 [![bench](https://github.com/DominicBurkart/marigold/workflows/bench/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/bench.yaml)
-[![codecov](https://codecov.io/gh/DominicBurkart/nanna-coder/graph/badge.svg?token=47S7xzd3Ny)](https://codecov.io/gh/DominicBurkart/nanna-coder)
+[![codecov](https://codecov.io/gh/DominicBurkart/marigold/graph/badge.svg)](https://codecov.io/gh/DominicBurkart/marigold)
 [![tests](https://github.com/DominicBurkart/marigold/workflows/tests/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/tests.yaml)
 [![style](https://github.com/DominicBurkart/marigold/workflows/style/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/style.yaml)
 [![wasm](https://github.com/DominicBurkart/marigold/workflows/wasm/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/wasm.yaml)

--- a/marigold-grammar/src/nodes.rs
+++ b/marigold-grammar/src/nodes.rs
@@ -269,7 +269,7 @@ pub struct StreamFunctionNode {
 }
 
 /// Number of inputs
-#[derive(PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub enum InputCount {
     Known(num_bigint::BigUint),
     /// Variant count for `range(EnumName)` — resolved to `Known` after symbol table lookup.
@@ -279,7 +279,7 @@ pub enum InputCount {
 
 /// Whether the input is known at compile time (constant),
 /// or whether it is not available until runtime (variable).
-#[derive(PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub enum InputVariability {
     Constant,
     Variable,

--- a/marigold-grammar/src/type_aggregation.rs
+++ b/marigold-grammar/src/type_aggregation.rs
@@ -241,7 +241,7 @@ mod tests {
                     _ => None,
                 }
             });
-            match (aggregate_input_count(cs.clone()), expected) {
+            match (aggregate_input_count(cs), expected) {
                 (InputCount::Known(got), Some(want)) => prop_assert_eq!(got, want),
                 (InputCount::Unknown, None) => {},
                 (InputCount::Enum(_), _) => prop_assert!(false, "aggregator emitted Enum"),

--- a/marigold-grammar/src/type_aggregation.rs
+++ b/marigold-grammar/src/type_aggregation.rs
@@ -26,3 +26,260 @@ pub fn aggregate_input_count<I: IntoIterator<Item = nodes::InputCount>>(
     }
     nodes::InputCount::Known(total_count)
 }
+
+#[cfg(test)]
+mod tests {
+    //! Tests pinning the invariants of the stream-input aggregators used by
+    //! `select_all` codegen (`pest_ast_builder::build_select_all_input`).
+    //!
+    //! Invariants validated:
+    //!
+    //! * `aggregate_input_variability` is the monoid-OR over `Variable`:
+    //!   the identity is `Constant`, and a single `Variable` anywhere in the
+    //!   iterator poisons the result.
+    //! * `aggregate_input_count` is a short-circuiting sum over `Known`
+    //!   with an absorbing element `Unknown` (which `Enum(_)` collapses to,
+    //!   because enum cardinality is resolved *after* aggregation by the
+    //!   symbol table pass). Empty input is the `Known(0)` identity.
+    //! * Both aggregators are order-insensitive in the sense that shuffling
+    //!   the iterator does not change the result.
+    //! * `Enum(_)` is never propagated through the output -- downstream code
+    //!   in `pest_ast_builder` relies on this and only ever sees `Known` or
+    //!   `Unknown`.
+    use super::*;
+    use nodes::{InputCount, InputVariability};
+    use num_bigint::BigUint;
+    use proptest::prelude::*;
+
+    // ---------- aggregate_input_variability ----------
+
+    #[test]
+    fn variability_empty_is_constant() {
+        let empty: Vec<InputVariability> = Vec::new();
+        assert!(aggregate_input_variability(empty) == InputVariability::Constant);
+    }
+
+    #[test]
+    fn variability_all_constant_is_constant() {
+        let all_const = vec![InputVariability::Constant; 5];
+        assert!(aggregate_input_variability(all_const) == InputVariability::Constant);
+    }
+
+    #[test]
+    fn variability_any_variable_is_variable() {
+        // Variable at the start, middle, and end -- position must not matter.
+        for position in 0..4 {
+            let mut v = vec![InputVariability::Constant; 4];
+            v[position] = InputVariability::Variable;
+            assert!(
+                aggregate_input_variability(v) == InputVariability::Variable,
+                "Variable at position {position} should poison the aggregate"
+            );
+        }
+    }
+
+    #[test]
+    fn variability_single_element_is_identity() {
+        assert!(
+            aggregate_input_variability([InputVariability::Constant]) == InputVariability::Constant
+        );
+        assert!(
+            aggregate_input_variability([InputVariability::Variable]) == InputVariability::Variable
+        );
+    }
+
+    fn arb_variability() -> impl Strategy<Value = InputVariability> {
+        prop_oneof![
+            Just(InputVariability::Constant),
+            Just(InputVariability::Variable),
+        ]
+    }
+
+    proptest! {
+        // Property: the aggregate is `Variable` iff any input is `Variable`.
+        #[test]
+        fn prop_variability_is_any_variable(vs in prop::collection::vec(arb_variability(), 0..16)) {
+            let has_variable = vs.contains(&InputVariability::Variable);
+            let expected = if has_variable {
+                InputVariability::Variable
+            } else {
+                InputVariability::Constant
+            };
+            prop_assert!(aggregate_input_variability(vs) == expected);
+        }
+
+        // Property: order does not change the aggregate (monoid is commutative).
+        #[test]
+        fn prop_variability_order_insensitive(
+            vs in prop::collection::vec(arb_variability(), 0..16),
+            seed in any::<u64>(),
+        ) {
+            let forward = aggregate_input_variability(vs.clone());
+            let mut shuffled = vs;
+            // Deterministic Fisher-Yates using a seeded xorshift prng to
+            // avoid pulling in `rand` as a dev-dep.
+            let mut state = seed | 1;
+            for i in (1..shuffled.len()).rev() {
+                state ^= state << 13;
+                state ^= state >> 7;
+                state ^= state << 17;
+                let j = (state as usize) % (i + 1);
+                shuffled.swap(i, j);
+            }
+            prop_assert!(forward == aggregate_input_variability(shuffled));
+        }
+    }
+
+    // ---------- aggregate_input_count ----------
+
+    fn known(n: u64) -> InputCount {
+        InputCount::Known(BigUint::from(n))
+    }
+
+    #[test]
+    fn count_empty_is_known_zero() {
+        let empty: Vec<InputCount> = Vec::new();
+        match aggregate_input_count(empty) {
+            InputCount::Known(n) => assert_eq!(n, BigUint::from(0u32)),
+            _ => panic!("empty iterator should aggregate to Known(0)"),
+        }
+    }
+
+    #[test]
+    fn count_all_known_sums() {
+        let counts = vec![known(1), known(2), known(3), known(4)];
+        match aggregate_input_count(counts) {
+            InputCount::Known(n) => assert_eq!(n, BigUint::from(10u32)),
+            _ => panic!("sum of Known should be Known"),
+        }
+    }
+
+    #[test]
+    fn count_unknown_is_absorbing() {
+        let with_unknown = vec![known(1), InputCount::Unknown, known(2)];
+        assert!(matches!(
+            aggregate_input_count(with_unknown),
+            InputCount::Unknown
+        ));
+    }
+
+    #[test]
+    fn count_enum_collapses_to_unknown() {
+        // `Enum(_)` represents a cardinality not yet resolved by the symbol
+        // table; the aggregator conservatively collapses it to `Unknown`
+        // rather than leaking the enum name.
+        let with_enum = vec![known(3), InputCount::Enum("Color".into()), known(5)];
+        assert!(matches!(
+            aggregate_input_count(with_enum),
+            InputCount::Unknown
+        ));
+    }
+
+    #[test]
+    fn count_never_emits_enum() {
+        // The output of the aggregator is only ever Known or Unknown.
+        // This is relied upon by `pest_ast_builder::build_select_all_input`.
+        let cases: Vec<Vec<InputCount>> = vec![
+            vec![],
+            vec![known(0)],
+            vec![InputCount::Enum("A".into())],
+            vec![InputCount::Unknown, InputCount::Enum("B".into())],
+            vec![known(1), known(2), InputCount::Enum("C".into())],
+        ];
+        for c in cases {
+            let out = aggregate_input_count(c);
+            assert!(
+                !matches!(out, InputCount::Enum(_)),
+                "aggregator must never emit Enum"
+            );
+        }
+    }
+
+    #[test]
+    fn count_short_circuits_without_consuming_tail() {
+        // Prove short-circuit: once we see Unknown, the remaining iterator
+        // items must not be pulled. We encode this as a panicking iterator
+        // tail -- the test passes only if short-circuit actually happens.
+        struct PanickingTail<I: Iterator<Item = InputCount>> {
+            head: std::vec::IntoIter<InputCount>,
+            tail: I,
+        }
+        impl<I: Iterator<Item = InputCount>> Iterator for PanickingTail<I> {
+            type Item = InputCount;
+            fn next(&mut self) -> Option<InputCount> {
+                if let Some(x) = self.head.next() {
+                    return Some(x);
+                }
+                self.tail.next()
+            }
+        }
+        let head = vec![known(1), InputCount::Unknown].into_iter();
+        let tail = std::iter::from_fn(|| -> Option<InputCount> {
+            panic!("tail pulled; short-circuit invariant violated");
+        });
+        let iter = PanickingTail { head, tail };
+        assert!(matches!(aggregate_input_count(iter), InputCount::Unknown));
+    }
+
+    fn arb_count() -> impl Strategy<Value = InputCount> {
+        prop_oneof![
+            (0u64..1_000).prop_map(known),
+            Just(InputCount::Unknown),
+            "[A-Z][a-zA-Z0-9]{0,8}".prop_map(InputCount::Enum),
+        ]
+    }
+
+    proptest! {
+        // Property: if every input is Known, the output is the arithmetic
+        // sum; otherwise the output is Unknown. The aggregator must never
+        // emit `Enum`.
+        #[test]
+        fn prop_count_matches_oracle(cs in prop::collection::vec(arb_count(), 0..16)) {
+            let expected: Option<BigUint> = cs.iter().try_fold(BigUint::from(0u32), |acc, c| {
+                match c {
+                    InputCount::Known(n) => Some(acc + n),
+                    _ => None,
+                }
+            });
+            match (aggregate_input_count(cs.clone()), expected) {
+                (InputCount::Known(got), Some(want)) => prop_assert_eq!(got, want),
+                (InputCount::Unknown, None) => {},
+                (InputCount::Enum(_), _) => prop_assert!(false, "aggregator emitted Enum"),
+                (got, want) => prop_assert!(
+                    false,
+                    "mismatch: got {:?}, want {:?}",
+                    match got {
+                        InputCount::Known(_) => "Known",
+                        InputCount::Unknown => "Unknown",
+                        InputCount::Enum(_) => "Enum",
+                    },
+                    want.map(|_| "Known").unwrap_or("Unknown")
+                ),
+            }
+        }
+
+        // Property: permuting a pure-Known input does not change the sum.
+        #[test]
+        fn prop_count_commutative_over_known(
+            ns in prop::collection::vec(0u64..10_000, 0..16),
+            seed in any::<u64>(),
+        ) {
+            let counts: Vec<InputCount> = ns.iter().copied().map(known).collect();
+            let mut shuffled = counts.clone();
+            let mut state = seed | 1;
+            for i in (1..shuffled.len()).rev() {
+                state ^= state << 13;
+                state ^= state >> 7;
+                state ^= state << 17;
+                let j = (state as usize) % (i + 1);
+                shuffled.swap(i, j);
+            }
+            let lhs = aggregate_input_count(counts);
+            let rhs = aggregate_input_count(shuffled);
+            match (lhs, rhs) {
+                (InputCount::Known(a), InputCount::Known(b)) => prop_assert_eq!(a, b),
+                _ => prop_assert!(false, "pure-Known input must aggregate to Known"),
+            }
+        }
+    }
+}

--- a/marigold/README.md
+++ b/marigold/README.md
@@ -6,7 +6,7 @@
 [![lines of code](https://raw.githubusercontent.com/DominicBurkart/marigold/main/development_metadata/badges/lines_of_code.svg)](https://github.com/DominicBurkart/marigold)
 [![contributors](https://raw.githubusercontent.com/DominicBurkart/marigold/main/development_metadata/badges/contributors.svg)](https://github.com/DominicBurkart/marigold/graphs/contributors)
 [![bench](https://github.com/DominicBurkart/marigold/workflows/bench/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/bench.yaml)
-[![codecov](https://codecov.io/gh/DominicBurkart/nanna-coder/graph/badge.svg?token=47S7xzd3Ny)](https://codecov.io/gh/DominicBurkart/nanna-coder)
+[![codecov](https://codecov.io/gh/DominicBurkart/marigold/graph/badge.svg)](https://codecov.io/gh/DominicBurkart/marigold)
 [![tests](https://github.com/DominicBurkart/marigold/workflows/tests/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/tests.yaml)
 [![style](https://github.com/DominicBurkart/marigold/workflows/style/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/style.yaml)
 [![wasm](https://github.com/DominicBurkart/marigold/workflows/wasm/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/wasm.yaml)

--- a/marigold/src/main.rs
+++ b/marigold/src/main.rs
@@ -195,7 +195,7 @@ tokio = {{ version = "1", features = ["full"]}}
         if !unoptimized {
             cargo_args.insert(1, "--release");
         }
-        Command::new("cargo").args(&cargo_args).spawn()?.wait()?
+        Command::new("cargo").args(cargo_args).spawn()?.wait()?
     } else {
         Command::new("cargo")
             .args([

--- a/marigold/src/main.rs
+++ b/marigold/src/main.rs
@@ -260,7 +260,7 @@ mod tests {
         )
         .expect("could not write test file");
 
-        let status = Command::new(&binary)
+        let status = Command::new(binary)
             .args(["run", marigold_file.to_str().unwrap()])
             .env("HOME", &tmp)
             .env("MARIGOLD_WORKSPACE_PATH", marigold_workspace_path())
@@ -292,7 +292,7 @@ mod tests {
         .expect("could not write test file");
 
         // Install the marigold program as a binary
-        let status = Command::new(&binary)
+        let status = Command::new(binary)
             .args(["install", marigold_file.to_str().unwrap()])
             .env("HOME", &tmp)
             .env("CARGO_INSTALL_ROOT", &install_root)
@@ -318,7 +318,7 @@ mod tests {
         );
 
         // Uninstall
-        let status = Command::new(&binary)
+        let status = Command::new(binary)
             .args(["uninstall", marigold_file.to_str().unwrap()])
             .env("HOME", &tmp)
             .env("CARGO_INSTALL_ROOT", &install_root)
@@ -348,7 +348,7 @@ mod tests {
         .expect("could not write test file");
 
         // Run first to create cache
-        let status = Command::new(&binary)
+        let status = Command::new(binary)
             .args(["run", marigold_file.to_str().unwrap()])
             .env("HOME", &tmp)
             .env("MARIGOLD_WORKSPACE_PATH", marigold_workspace_path())
@@ -360,7 +360,7 @@ mod tests {
         assert!(cache_dir.exists(), "cache should exist after run");
 
         // Clean
-        let status = Command::new(&binary)
+        let status = Command::new(binary)
             .args(["clean", marigold_file.to_str().unwrap()])
             .env("HOME", &tmp)
             .env("MARIGOLD_WORKSPACE_PATH", marigold_workspace_path())
@@ -390,7 +390,7 @@ mod tests {
         .expect("could not write test file");
 
         // Run first to create cache
-        let status = Command::new(&binary)
+        let status = Command::new(binary)
             .args(["run", marigold_file.to_str().unwrap()])
             .env("HOME", &tmp)
             .env("MARIGOLD_WORKSPACE_PATH", marigold_workspace_path())
@@ -402,7 +402,7 @@ mod tests {
         assert!(cache_root.exists(), "cache should exist after run");
 
         // Clean all
-        let status = Command::new(&binary)
+        let status = Command::new(binary)
             .args(["clean-all"])
             .env("HOME", &tmp)
             .env("MARIGOLD_WORKSPACE_PATH", marigold_workspace_path())

--- a/marigold/src/main.rs
+++ b/marigold/src/main.rs
@@ -124,12 +124,12 @@ fn main() -> Result<()> {
                 .unwrap_or(0),
         ),
         Some(Clean { .. }) => {
-            std::fs::remove_dir_all(&program_project_dir)?;
+            std::fs::remove_dir_all(program_project_dir)?;
             std::process::exit(0);
         }
         Some(CleanAll) => {
             if marigold_cache_directory.exists() {
-                std::fs::remove_dir_all(&marigold_cache_directory)?;
+                std::fs::remove_dir_all(marigold_cache_directory)?;
             }
             std::process::exit(0);
         }
@@ -151,8 +151,7 @@ fn main() -> Result<()> {
 
     std::fs::write(
         program_src_dir.join("main.rs"),
-        format!("#[tokio::main] async fn main() {{ marigold::m!({program_contents}).await }}")
-            .as_str(),
+        format!("#[tokio::main] async fn main() {{ marigold::m!({program_contents}).await }}"),
     )?;
 
     const MARIGOLD_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/marigold/src/main.rs
+++ b/marigold/src/main.rs
@@ -182,13 +182,15 @@ tokio = {{ version = "1", features = ["full"]}}
 
     let utf8_err = "Marigold could not parse cache manifest path as utf-8";
     let exit_status = if command == "run" {
-        let unoptimized = matches!(
-            &args.command,
-            Some(Run {
-                unoptimized: true,
-                ..
-            })
-        );
+        let unoptimized = if let Some(Run {
+            unoptimized,
+            file: _,
+        }) = &args.command
+        {
+            *unoptimized
+        } else {
+            false
+        };
         let manifest = manifest_path.to_str().expect(utf8_err);
         let mut cargo_args = vec![command, "--manifest-path", manifest];
         if !unoptimized {

--- a/marigold/src/main.rs
+++ b/marigold/src/main.rs
@@ -269,11 +269,11 @@ mod tests {
         assert!(status.success(), "marigold run failed");
 
         assert_eq!(
-            fs::read_to_string(&csv_file).expect("could not read CSV"),
+            fs::read_to_string(csv_file).expect("could not read CSV"),
             "0\n1\n2\n"
         );
 
-        let _ = fs::remove_dir_all(&tmp);
+        let _ = fs::remove_dir_all(tmp);
     }
 
     #[test]
@@ -331,7 +331,7 @@ mod tests {
             "installed binary should be removed after uninstall"
         );
 
-        let _ = fs::remove_dir_all(&tmp);
+        let _ = fs::remove_dir_all(tmp);
     }
 
     #[test]
@@ -373,7 +373,7 @@ mod tests {
             "cache dir should be removed after clean"
         );
 
-        let _ = fs::remove_dir_all(&tmp);
+        let _ = fs::remove_dir_all(tmp);
     }
 
     #[test]
@@ -415,6 +415,6 @@ mod tests {
             "entire cache should be removed after clean-all"
         );
 
-        let _ = fs::remove_dir_all(&tmp);
+        let _ = fs::remove_dir_all(tmp);
     }
 }

--- a/marigold/src/main.rs
+++ b/marigold/src/main.rs
@@ -57,17 +57,13 @@ fn main() {
 fn get_file_name_argument(args: &Args) -> Option<String> {
     use MarigoldCommand::*;
 
-    match &args.command {
-        Some(Run {
-            unoptimized: _,
-            file,
-        }) => file.clone(),
-        Some(Install { file }) => file.clone(),
-        Some(Uninstall { file }) => file.clone(),
-        Some(Clean { file }) => file.clone(),
-        Some(Analyze { file }) => file.clone(),
-        Some(CleanAll) => None,
-        None => None,
+    match args.command.as_ref()? {
+        Run { file, .. }
+        | Install { file }
+        | Uninstall { file }
+        | Clean { file }
+        | Analyze { file } => file.clone(),
+        CleanAll => None,
     }
 }
 
@@ -91,91 +87,67 @@ fn main() -> Result<()> {
     let file_name_argument = get_file_name_argument(&args);
 
     let program_name = {
-        let mut file_name = match &file_name_argument {
-            Some(path) => {
-                let stem = std::path::Path::new(path)
+        let stem = file_name_argument
+            .as_deref()
+            .and_then(|path| {
+                std::path::Path::new(path)
                     .file_stem()
                     .and_then(|s| s.to_str())
-                    .unwrap_or("marigold_program");
-                if stem.len() > 1 {
-                    stem.to_string()
-                } else {
-                    "marigold_program".to_string()
-                }
-            }
-            None => "marigold_program".to_string(),
-        };
-
-        file_name = file_name.to_case(Case::Snake);
-        file_name = file_name
-            .strip_prefix("_")
-            .map(|s| s.to_string())
-            .unwrap_or(file_name);
-        file_name = file_name
-            .strip_suffix("_")
-            .map(|s| s.to_string())
-            .unwrap_or(file_name);
-        file_name
+                    .filter(|s| s.len() > 1)
+            })
+            .unwrap_or("marigold_program");
+        stem.to_case(Case::Snake).trim_matches('_').to_string()
     };
 
     let program_project_dir = marigold_cache_directory.join(&program_name);
 
-    let command = match args.command {
-        Some(ref command) => match command {
-            Run {
-                unoptimized: _,
-                file: _,
-            } => "run",
-            Install { file: _ } => "install",
-            Uninstall { file: _ } => std::process::exit(
-                Command::new("cargo")
-                    .args(["uninstall", &program_name])
-                    .spawn()?
-                    .wait()?
-                    .code()
-                    .unwrap_or(0),
-            ),
-            Clean { file: _ } => {
-                std::fs::remove_dir_all(&program_project_dir)?;
-                std::process::exit(0);
+    let read_program = || -> Result<String> {
+        Ok(match &file_name_argument {
+            Some(path) => std::fs::read_to_string(path)?.trim().to_string(),
+            None => {
+                let mut stdin = String::new();
+                io::stdin().lock().read_to_string(&mut stdin)?;
+                stdin.trim().to_string()
             }
-            CleanAll => {
-                if marigold_cache_directory.exists() {
-                    std::fs::remove_dir_all(&marigold_cache_directory)?;
-                }
-                std::process::exit(0);
+        })
+    };
+
+    let command = match &args.command {
+        Some(Run { .. }) | None => "run", // default is run.
+        Some(Install { .. }) => "install",
+        Some(Uninstall { .. }) => std::process::exit(
+            Command::new("cargo")
+                .args(["uninstall", &program_name])
+                .spawn()?
+                .wait()?
+                .code()
+                .unwrap_or(0),
+        ),
+        Some(Clean { .. }) => {
+            std::fs::remove_dir_all(&program_project_dir)?;
+            std::process::exit(0);
+        }
+        Some(CleanAll) => {
+            if marigold_cache_directory.exists() {
+                std::fs::remove_dir_all(&marigold_cache_directory)?;
             }
-            Analyze { file: _ } => {
-                let program_contents = match &file_name_argument {
-                    Some(path) => std::fs::read_to_string(path)?.trim().to_string(),
-                    None => {
-                        let mut stdin = String::new();
-                        io::stdin().lock().read_to_string(&mut stdin)?;
-                        stdin.trim().to_string()
-                    }
-                };
-                let result = marigold_grammar::marigold_analyze(&program_contents)
-                    .map_err(|e| anyhow::anyhow!("{}", e))?;
-                let json = serde_json::to_string_pretty(&result)?;
-                println!("{json}");
-                std::process::exit(0);
-            }
-        },
-        None => "run", // default is run.
+            std::process::exit(0);
+        }
+        Some(Analyze { .. }) => {
+            let program_contents = read_program()?;
+            let result = marigold_grammar::marigold_analyze(&program_contents)
+                .map_err(|e| anyhow::anyhow!("{}", e))?;
+            let json = serde_json::to_string_pretty(&result)?;
+            println!("{json}");
+            std::process::exit(0);
+        }
     };
 
     let program_src_dir = program_project_dir.join("src");
 
     std::fs::create_dir_all(&program_src_dir)?;
 
-    let program_contents = match file_name_argument {
-        Some(path) => std::fs::read_to_string(&path)?.trim().to_string(),
-        None => {
-            let mut stdin = String::new();
-            io::stdin().lock().read_to_string(&mut stdin)?;
-            stdin.trim().to_string()
-        }
-    };
+    let program_contents = read_program()?;
 
     std::fs::write(
         program_src_dir.join("main.rs"),
@@ -209,55 +181,30 @@ tokio = {{ version = "1", features = ["full"]}}
         ),
     )?;
 
-    let exit_status = {
-        if command == "run" {
-            let unoptimized = {
-                if let Some(Run {
-                    unoptimized,
-                    file: _,
-                }) = &args.command
-                {
-                    *unoptimized
-                } else {
-                    false
-                }
-            };
-            if unoptimized {
-                Command::new("cargo")
-                    .args([
-                        command,
-                        "--manifest-path",
-                        manifest_path
-                            .to_str()
-                            .expect("Marigold could not parse cache manifest path as utf-8"),
-                    ])
-                    .spawn()?
-                    .wait()?
-            } else {
-                Command::new("cargo")
-                    .args([
-                        command,
-                        "--release",
-                        "--manifest-path",
-                        manifest_path
-                            .to_str()
-                            .expect("Marigold could not parse cache manifest path as utf-8"),
-                    ])
-                    .spawn()?
-                    .wait()?
-            }
-        } else {
-            Command::new("cargo")
-                .args([
-                    command,
-                    "--path",
-                    program_project_dir
-                        .to_str()
-                        .expect("Marigold could not parse cache manifest path as utf-8"),
-                ])
-                .spawn()?
-                .wait()?
+    let utf8_err = "Marigold could not parse cache manifest path as utf-8";
+    let exit_status = if command == "run" {
+        let unoptimized = matches!(
+            &args.command,
+            Some(Run {
+                unoptimized: true,
+                ..
+            })
+        );
+        let manifest = manifest_path.to_str().expect(utf8_err);
+        let mut cargo_args = vec![command, "--manifest-path", manifest];
+        if !unoptimized {
+            cargo_args.insert(1, "--release");
         }
+        Command::new("cargo").args(&cargo_args).spawn()?.wait()?
+    } else {
+        Command::new("cargo")
+            .args([
+                command,
+                "--path",
+                program_project_dir.to_str().expect(utf8_err),
+            ])
+            .spawn()?
+            .wait()?
     };
 
     std::process::exit(exit_status.code().unwrap_or(0));


### PR DESCRIPTION
## Component

`marigold-grammar/src/type_aggregation.rs` — the two aggregators (`aggregate_input_variability`, `aggregate_input_count`) consumed by `pest_ast_builder::build_select_all_input` when lowering `select_all(...)` to `futures::stream::select_all`.

(This PR also carries two prior drive-by commits already on this branch: a codecov badge fix and a `main.rs` CLI dispatch refactor. Summarized at bottom.)

## Disposition

`type_aggregation.rs` had **zero tests** before this PR. It was the only non-trivial file in `marigold-grammar/src/` without any `#[test]` or `proptest!` coverage, and it is load-bearing — a wrong aggregate silently mis-types every `select_all` in the IR (wrong variability / wrong cardinality), which then flows into the complexity analyzer and codegen.

## Invariants

**`aggregate_input_variability`** — monoid-OR over `Variable`:
- identity: `Constant` (empty input → `Constant`);
- absorbing element: any `Variable` anywhere → `Variable`;
- commutative (order-insensitive).

**`aggregate_input_count`** — short-circuiting sum over `Known` with an absorbing element:
- identity: `Known(0)` (empty input);
- `Unknown` is absorbing;
- `Enum(_)` collapses to `Unknown` (enum cardinality is resolved *after* aggregation, by the symbol-table pass) — the aggregator must **never** emit `Enum`, a property downstream `pest_ast_builder` code depends on;
- short-circuits: once `Unknown` is observed, the remaining iterator items are not pulled;
- commutative over pure-`Known` inputs.

## Strategy & why

**Unit tests + proptest** inline under `#[cfg(test)] mod tests` — 14 new tests (10 `#[test]`, 4 `proptest!`).

- **Unit tests** pin corner cases: empty iterator, single element, `Variable`/`Unknown`/`Enum(_)` at each position, pure-`Known` sum.
- **Proptest** covers the behavioural properties the corner cases cannot enumerate: "aggregate is `Variable` iff any input is `Variable`"; "aggregate is `Known(sum)` iff all inputs are `Known`, else `Unknown`, and never `Enum`"; order-insensitivity under a deterministic Fisher-Yates shuffle (seeded xorshift, so no new `rand` dev-dep).
- **Short-circuit test** uses a `PanickingTail` iterator adapter: the tail after an `Unknown` panics on `next()`, so the test passes only if the aggregator actually short-circuits. A value-equality assertion couldn't catch this regression.

Why proptest over alternatives: these functions are small, pure, deterministic, and take `IntoIterator` — property tests are an order of magnitude better at stressing the algebraic properties than end-to-end codegen tests (which already cover the happy path through `build_select_all_input` but can't exercise the aggregator's absorbing/identity/commutativity laws).

Drive-by: derive `Debug` on `nodes::InputCount` and `nodes::InputVariability` to match the rest of the AST enums in that module and to let proptest format shrink failures.

## Test plan

- [x] `cargo test -p marigold-grammar --lib` — 309 passed (295 existing + 14 new)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p marigold-grammar --lib --all-features -- -D warnings`
- [ ] CI green on this PR

## Prior commits on this branch (context)

- `docs: fix codecov badge URL pointing to wrong repo` (6fca66e) — both READMEs pointed at `DominicBurkart/nanna-coder` instead of `DominicBurkart/marigold`.
- `refactor(cli): simplify main.rs file-arg/command dispatch` (811ea04) — -53 LOC in `marigold/src/main.rs`, no behavior change (4 bin tests still pass).

https://claude.ai/code/session_017vrZ4D421Ty4uKSgmm7Qsb