### PR TITLE
fix: use --no-gpg-sign instead of config workaround (closes #68)

### DIFF
--- a/marigold-grammar/tests/bisect_cardinality.rs
+++ b/marigold-grammar/tests/bisect_cardinality.rs
@@ -29,7 +29,7 @@ fn commit_hash(dir: &std::path::Path) -> String {
 fn write_and_commit(dir: &std::path::Path, content: &str, message: &str) -> String {
     std::fs::write(dir.join("program.marigold"), content).unwrap();
     git(dir, &["add", "program.marigold"]);
-    git(dir, &["commit", "-m", message]);
+    git(dir, &["commit", "--no-gpg-sign", "-m", message]);
     commit_hash(dir)
 }
 
@@ -47,7 +47,6 @@ fn test_bisect_detects_exact_to_bounded_regression() {
     git(dir, &["init"]);
     git(dir, &["config", "user.email", "test@test.com"]);
     git(dir, &["config", "user.name", "Test"]);
-    git(dir, &["config", "commit.gpgsign", "false"]);
 
     let commit_a = write_and_commit(
         dir,

--- a/marigold-grammar/tests/bisect_complexity.rs
+++ b/marigold-grammar/tests/bisect_complexity.rs
@@ -29,7 +29,7 @@ fn commit_hash(dir: &std::path::Path) -> String {
 fn write_and_commit(dir: &std::path::Path, content: &str, message: &str) -> String {
     std::fs::write(dir.join("program.marigold"), content).unwrap();
     git(dir, &["add", "program.marigold"]);
-    git(dir, &["commit", "-m", message]);
+    git(dir, &["commit", "--no-gpg-sign", "-m", message]);
     commit_hash(dir)
 }
 
@@ -47,7 +47,6 @@ fn test_git_bisect_detects_memory_regression() {
     git(dir, &["init"]);
     git(dir, &["config", "user.email", "test@test.com"]);
     git(dir, &["config", "user.name", "Test"]);
-    git(dir, &["config", "commit.gpgsign", "false"]);
 
     let commit_a = write_and_commit(
         dir,

--- a/marigold-grammar/tests/no_gpg_config_workaround.rs
+++ b/marigold-grammar/tests/no_gpg_config_workaround.rs
@@ -1,0 +1,14 @@
+//! Regression guard: issue #68.
+//! Fails if the `git config commit.gpgsign false` workaround is reintroduced.
+
+#[test]
+fn bisect_tests_do_not_configure_gpg() {
+    let cardinality = include_str!("bisect_cardinality.rs");
+    let complexity = include_str!("bisect_complexity.rs");
+    for (name, src) in [("cardinality", cardinality), ("complexity", complexity)] {
+        assert!(
+            !src.contains("commit.gpgsign"),
+            "{name} bisect test reintroduces the gpg config workaround (issue #68)",
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes #68 — "solve gpg miscconfiguration". Cherries #159's Rust-side fix (pass `--no-gpg-sign` directly on `git commit` invocations) onto current main, and adds a regression-guard test.

## Fingerprint

```
job-id: QO4Td
oldest-issue-id: one_track#2
this-issue: marigold#68
supersedes: marigold#159
parent-sha: fba35752597aeeb8d316bba272d1c1ef5030766d
base-at-fork: 4bbe781e303dd0329a66722ea084b39afe7287a8
```

## Changes

1. Replaced `git config commit.gpgsign false` step with `--no-gpg-sign` on `git commit` in bisect tests (`marigold-grammar/tests/bisect_cardinality.rs`, `marigold-grammar/tests/bisect_complexity.rs`).
2. Added `marigold-grammar/tests/no_gpg_config_workaround.rs` regression guard — fails if the old config workaround is reintroduced into either bisect test.

## Deferred

`.github/workflows/badges.yaml:47` update (`git commit` → `git commit --no-gpg-sign`) requires `workflows` token scope which the CRON agent does not have. Filed as a human-applied follow-up — a repo admin can apply this one-line change directly.

## Feedback loops

CI runs `Tests` on every PR — the regression guard piggybacks on it; any future PR that reintroduces `commit.gpgsign` config will fail `cargo test -p marigold-grammar`.

## Test plan

- [x] `cargo fmt --check` (clean)
- [x] `cargo test -p marigold-grammar` (29 tests pass including the new regression guard)
- [x] `cargo clippy -p marigold-grammar --test no_gpg_config_workaround -- -D warnings` (clean)
- [ ] Pre-existing clippy `-D warnings` errors on `marigold/src/main.rs` and `marigold-grammar/src/pest_ast_builder.rs` exist on `main` prior to this PR and are out of scope.

Closes #68

https://claude.ai/code/session_01JoDLmeYFCnEEmFmXBV25qY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoDLmeYFCnEEmFmXBV25qY)_