### PR TITLE
test: cover MultiConsumerStream, RunFutureAsStream, type aggregation, run_stream

### DIFF
--- a/marigold-grammar/src/type_aggregation.rs
+++ b/marigold-grammar/src/type_aggregation.rs
@@ -26,3 +26,78 @@ pub fn aggregate_input_count<I: IntoIterator<Item = nodes::InputCount>>(
     }
     nodes::InputCount::Known(total_count)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::nodes::{InputCount, InputVariability};
+    use num_bigint::BigUint;
+
+    #[test]
+    fn variability_empty_is_constant() {
+        assert!(
+            aggregate_input_variability(std::iter::empty::<InputVariability>())
+                == InputVariability::Constant
+        );
+    }
+
+    #[test]
+    fn variability_all_constant_is_constant() {
+        assert!(
+            aggregate_input_variability(vec![
+                InputVariability::Constant,
+                InputVariability::Constant,
+                InputVariability::Constant,
+            ]) == InputVariability::Constant
+        );
+    }
+
+    #[test]
+    fn variability_any_variable_is_variable() {
+        assert!(
+            aggregate_input_variability(vec![
+                InputVariability::Constant,
+                InputVariability::Variable,
+                InputVariability::Constant,
+            ]) == InputVariability::Variable
+        );
+    }
+
+    #[test]
+    fn count_empty_is_known_zero() {
+        let result = aggregate_input_count(std::iter::empty::<InputCount>());
+        assert!(result == InputCount::Known(BigUint::from(0_u32)));
+    }
+
+    #[test]
+    fn count_sums_known_values() {
+        let result = aggregate_input_count(vec![
+            InputCount::Known(BigUint::from(2_u32)),
+            InputCount::Known(BigUint::from(3_u32)),
+            InputCount::Known(BigUint::from(7_u32)),
+        ]);
+        assert!(result == InputCount::Known(BigUint::from(12_u32)));
+    }
+
+    /// Encountering Unknown short-circuits regardless of any Known summands.
+    #[test]
+    fn count_unknown_propagates() {
+        let result = aggregate_input_count(vec![
+            InputCount::Known(BigUint::from(5_u32)),
+            InputCount::Unknown,
+            InputCount::Known(BigUint::from(10_u32)),
+        ]);
+        assert!(result == InputCount::Unknown);
+    }
+
+    /// An unresolved `Enum` placeholder behaves like Unknown for the purposes
+    /// of compile-time aggregation.
+    #[test]
+    fn count_unresolved_enum_propagates_as_unknown() {
+        let result = aggregate_input_count(vec![
+            InputCount::Known(BigUint::from(1_u32)),
+            InputCount::Enum("Words".to_string()),
+        ]);
+        assert!(result == InputCount::Unknown);
+    }
+}

--- a/marigold-impl/src/multi_consumer_stream.rs
+++ b/marigold-impl/src/multi_consumer_stream.rs
@@ -100,3 +100,73 @@ impl<T: std::marker::Send + Unpin + 'static, O, F: Future<Output = O>> Stream
         (0, None)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream::StreamExt;
+
+    /// One consumer should observe every item produced by the inner stream.
+    #[tokio::test]
+    async fn multi_consumer_single_consumer_passthrough() {
+        let mut mcs = MultiConsumerStream::new(futures::stream::iter(0_u32..5_u32));
+        let consumer = mcs.get();
+        tokio::spawn(mcs.run());
+        assert_eq!(consumer.collect::<Vec<_>>().await, vec![0, 1, 2, 3, 4]);
+    }
+
+    /// Every registered consumer should observe every item, in order.
+    #[tokio::test]
+    async fn multi_consumer_broadcast_to_three() {
+        let mut mcs = MultiConsumerStream::new(futures::stream::iter(10_u32..14_u32));
+        let a = mcs.get();
+        let b = mcs.get();
+        let c = mcs.get();
+        tokio::spawn(mcs.run());
+
+        let (va, vb, vc) = tokio::join!(
+            a.collect::<Vec<_>>(),
+            b.collect::<Vec<_>>(),
+            c.collect::<Vec<_>>(),
+        );
+        assert_eq!(va, vec![10, 11, 12, 13]);
+        assert_eq!(vb, vec![10, 11, 12, 13]);
+        assert_eq!(vc, vec![10, 11, 12, 13]);
+    }
+
+    /// With no consumers, run() should still complete cleanly.
+    #[tokio::test]
+    async fn multi_consumer_no_consumers_completes() {
+        let mcs = MultiConsumerStream::new(futures::stream::iter(0_u32..3_u32));
+        let handle = tokio::spawn(mcs.run());
+        handle.await.expect("run() should complete cleanly");
+    }
+
+    /// An empty inner stream should yield zero items to a registered consumer
+    /// and still cause the consumer's stream to terminate.
+    #[tokio::test]
+    async fn multi_consumer_empty_inner_terminates() {
+        let mut mcs = MultiConsumerStream::new(futures::stream::iter(std::iter::empty::<u32>()));
+        let consumer = mcs.get();
+        tokio::spawn(mcs.run());
+        assert_eq!(consumer.collect::<Vec<_>>().await, Vec::<u32>::new());
+    }
+
+    /// `RunFutureAsStream` adapts a Future into a Stream that yields no items but
+    /// terminates after the future resolves.
+    #[tokio::test]
+    async fn run_future_as_stream_yields_nothing_then_terminates() {
+        let fut = Box::pin(async { 42_u32 });
+        let stream: RunFutureAsStream<(), u32, _> = RunFutureAsStream::new(fut);
+        let collected: Vec<()> = stream.collect().await;
+        assert!(collected.is_empty());
+    }
+
+    /// `size_hint` should report (0, None) — the adapter never produces items.
+    #[test]
+    fn run_future_as_stream_size_hint_is_zero_unbounded() {
+        let fut = Box::pin(async {});
+        let stream: RunFutureAsStream<(), (), _> = RunFutureAsStream::new(fut);
+        assert_eq!(stream.size_hint(), (0, None));
+    }
+}

--- a/marigold-impl/src/run_stream.rs
+++ b/marigold-impl/src/run_stream.rs
@@ -48,4 +48,21 @@ mod tests {
             vec![0_u32, 1_u32, 2_u32]
         );
     }
+
+    #[tokio::test]
+    async fn run_stream_preserves_order_for_long_stream() {
+        let n = 1024_u32;
+        let collected = run_stream(futures::stream::iter(0_u32..n))
+            .collect::<Vec<_>>()
+            .await;
+        assert_eq!(collected, (0..n).collect::<Vec<_>>());
+    }
+
+    #[tokio::test]
+    async fn run_stream_empty_stream_yields_nothing() {
+        let collected = run_stream(futures::stream::iter(std::iter::empty::<u32>()))
+            .collect::<Vec<_>>()
+            .await;
+        assert!(collected.is_empty());
+    }
 }


### PR DESCRIPTION
## Summary

Adds tests to four previously zero- or single-test modules.

- `marigold-impl/src/multi_consumer_stream.rs` had no tests at all. Added six tests covering single-consumer pass-through, broadcast to multiple consumers, no-consumers completion, empty-inner termination, the `RunFutureAsStream` adapter (terminates yielding nothing), and its `size_hint` contract.
- `marigold-grammar/src/type_aggregation.rs` had no tests. Added seven unit tests covering the empty-iterator base cases, all-constant pass-through, any-variable propagation for `aggregate_input_variability`, and the empty/sum/Unknown-short-circuit/unresolved-Enum-short-circuit cases for `aggregate_input_count`.
- `marigold-impl/src/run_stream.rs` had a single happy-path test. Added long-stream order-preservation and empty-stream termination cases.

`InputCount`/`InputVariability` do not derive `Debug`, so the `assert!(... == ...)` form is used instead of `assert_eq!` to avoid widening the public type surface for tests alone.

## Test plan

- [x] `cargo test --workspace --exclude marigold --features tokio` — passes locally with all new tests
- [x] `cargo clippy --all-features --workspace -- -D warnings` — passes locally
- [x] `cargo fmt --all -- --check` — passes locally

## CI status

Two pre-existing failures appear on this PR and on the sibling arch PR (#193), neither of which touch the relevant code paths:

- `Tests` (workflow `tests.yaml`, `cargo test` job): also red on the arch PR which only edits `marigold-impl` and `marigold-grammar` benches/lib. Investigation required upstream — the failure occurs in <70s, suggesting an infrastructure/cargo issue rather than a test regression. The newly added tests in this PR all pass locally with `cargo test --features tokio`.
- `style hooks`: also red on the arch PR. The workflow runs `cargo audit && cargo deny check` plus `markdownlint`; advisory feeds drift independently of source changes.

Coverage delta: not measured (tarpaulin not installable in this sandbox). The new tests add coverage to two previously zero-test modules and extend a third.

https://claude.ai/code/session_01FzKpNrStguLtayd2ia2SKq