### PR TITLE
[test] cover MultiConsumerStream invariants

### DIFF
--- a/marigold-impl/src/multi_consumer_stream.rs
+++ b/marigold-impl/src/multi_consumer_stream.rs
@@ -100,3 +100,85 @@ impl<T: std::marker::Send + Unpin + 'static, O, F: Future<Output = O>> Stream
         (0, None)
     }
 }
+
+#[cfg(all(test, any(feature = "tokio", feature = "async-std")))]
+mod tests {
+    use super::MultiConsumerStream;
+    use futures::stream::StreamExt;
+
+    /// Each consumer must observe the entire source stream in source order.
+    #[tokio::test]
+    async fn single_consumer_sees_full_stream_in_order() {
+        let source = futures::stream::iter(0u32..16);
+        let mut mcs = MultiConsumerStream::new(source);
+        let consumer = mcs.get();
+        mcs.run().await;
+
+        let collected: Vec<u32> = consumer.collect().await;
+        assert_eq!(collected, (0u32..16).collect::<Vec<_>>());
+    }
+
+    /// Two consumers attached to the same source must each see every item
+    /// in the same order as the source emitted them.
+    #[tokio::test]
+    async fn multiple_consumers_each_see_full_stream_in_order() {
+        let source = futures::stream::iter(0u32..32);
+        let mut mcs = MultiConsumerStream::new(source);
+        let a = mcs.get();
+        let b = mcs.get();
+        let c = mcs.get();
+        mcs.run().await;
+
+        let (va, vb, vc) = futures::join!(
+            a.collect::<Vec<_>>(),
+            b.collect::<Vec<_>>(),
+            c.collect::<Vec<_>>(),
+        );
+        let expected: Vec<u32> = (0u32..32).collect();
+        assert_eq!(va, expected);
+        assert_eq!(vb, expected);
+        assert_eq!(vc, expected);
+    }
+
+    /// An empty source stream must terminate every attached consumer
+    /// without producing any items.
+    #[tokio::test]
+    async fn empty_source_disconnects_all_consumers() {
+        let source = futures::stream::iter(Vec::<u32>::new());
+        let mut mcs = MultiConsumerStream::new(source);
+        let a = mcs.get();
+        let b = mcs.get();
+        mcs.run().await;
+
+        let (va, vb) = futures::join!(a.collect::<Vec<_>>(), b.collect::<Vec<_>>());
+        assert!(va.is_empty());
+        assert!(vb.is_empty());
+    }
+
+    /// Running with no consumers attached should still drain the source
+    /// without panicking.
+    #[tokio::test]
+    async fn run_with_no_consumers_does_not_panic() {
+        let source = futures::stream::iter(0u32..8);
+        let mcs = MultiConsumerStream::new(source);
+        // No `.get()` calls.
+        mcs.run().await;
+    }
+
+    /// Each consumer must own an independent copy of every item: dropping or
+    /// fully draining one consumer must not affect the items observed by the
+    /// others (modulo ordering, which is preserved per-consumer).
+    #[tokio::test]
+    async fn consumers_observe_independent_item_copies() {
+        let source = futures::stream::iter(vec![10u64, 20, 30, 40, 50]);
+        let mut mcs = MultiConsumerStream::new(source);
+        let a = mcs.get();
+        let b = mcs.get();
+        mcs.run().await;
+
+        let (va, vb) = futures::join!(a.collect::<Vec<_>>(), b.collect::<Vec<_>>());
+        assert_eq!(va, vec![10, 20, 30, 40, 50]);
+        assert_eq!(vb, vec![10, 20, 30, 40, 50]);
+        // If items were moved instead of copied, only one consumer could see them.
+    }
+}


### PR DESCRIPTION
## Target
`marigold-impl/src/multi_consumer_stream.rs` — `MultiConsumerStream<T, S>`,
the fan-out adapter that lets one source stream feed N independent consumers.
Pre-existing inline test count: **0**. Despite being a `pub` component
exercised by the `multi-consumer` example, no targeted unit tests covered it.

## Disposition
Pure async glue: subscribes Senders, spawns a task that polls the source
stream and feeds each item to every Sender (concurrently via
`FuturesUnordered`), then disconnects all Senders on EOS.

## Invariants under test
1. **Order preservation per consumer** — every consumer observes items in
   the exact source order.
2. **Broadcast completeness** — every consumer observes every item (no item
   delivered to only a subset of consumers).
3. **Termination** — when the source stream completes, every Receiver is
   closed (consumers' streams complete).
4. **Empty source** — consumers attached to an empty source still terminate
   cleanly with zero items.
5. **No-consumer run** — `run()` with zero attached consumers drains the
   source without panicking.
6. **Per-consumer item copies** — the `T: Copy` bound means each consumer
   owns an independent copy; one consumer's observations are independent of
   another's.

## Strategy
Inline `#[cfg(test)]` module gated on `any(feature = "tokio", feature =
"async-std")` (matching the impl). Five focused `#[tokio::test]` cases
covering the invariants above, using `futures::stream::iter` sources and
`futures::join!` for parallel consumer drain.

No production code changes. No new dependencies. Coverage of a previously
zero-test public component.

https://claude.ai/code/session_01Ufspun8cJLsqJmeuYvP1Fk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ufspun8cJLsqJmeuYvP1Fk)_