### PR TITLE
[arch] Remove redundant `extern crate proc_macro` declarations

### DIFF
--- a/marigold-grammar/src/lib.rs
+++ b/marigold-grammar/src/lib.rs
@@ -62,8 +62,6 @@
 //! - **Code generation**: Dominates runtime, scales with program complexity
 //! - **Binary size**: Pest parser adds ~40KB to binary size
 
-extern crate proc_macro;
-
 pub use itertools;
 
 pub mod bound_resolution;

--- a/marigold-macros/src/lib.rs
+++ b/marigold-macros/src/lib.rs
@@ -1,6 +1,5 @@
 #![forbid(unsafe_code)]
 
-extern crate proc_macro;
 use marigold_grammar::marigold_parse;
 use proc_macro::TokenStream;
 


### PR DESCRIPTION
## Violation

`-W unused-extern-crates` flagged two redundant `extern crate proc_macro;` declarations:

- `marigold-grammar/src/lib.rs:65` — `marigold-grammar` is **not** a proc-macro crate, and `proc_macro` is never referenced anywhere in the file. The line was pure dead code.
- `marigold-macros/src/lib.rs:3` — the symbol is already brought into scope on the next line via `use proc_macro::TokenStream;`. Since Rust 2018 (both crates declare `edition = "2021"`), `extern crate` is no longer required for std/proc_macro.

## Fix

Removed both `extern crate proc_macro;` lines.

## Verification

- `cargo build --workspace` — clean
- `cargo clippy --workspace --no-deps -- -W unused-extern-crates` — no warnings
- `cargo test -p marigold-grammar --lib` — 295 passed, 0 failed

No behavior change; this is a pure cleanup.

https://claude.ai/code/session_01Ufspun8cJLsqJmeuYvP1Fk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ufspun8cJLsqJmeuYvP1Fk)_