### PR TITLE
fix(marigold): emit compile_error! instead of panic in marigold! proc macro for better diagnostics

### DIFF
--- a/marigold-macros/Cargo.toml
+++ b/marigold-macros/Cargo.toml
@@ -17,6 +17,8 @@ io = ["marigold-grammar/io"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+proc-macro2 = "1"
+quote = "1"
 
 [dependencies.marigold-grammar]
 path = "../marigold-grammar"

--- a/marigold-macros/src/lib.rs
+++ b/marigold-macros/src/lib.rs
@@ -3,14 +3,21 @@
 extern crate proc_macro;
 use marigold_grammar::marigold_parse;
 use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::quote_spanned;
 
 #[proc_macro]
 pub fn marigold(item: TokenStream) -> TokenStream {
     let s = item.to_string();
-    format!(
-        "{{\n{}\n}}\n",
-        marigold_parse(&s).expect("marigold parsing error")
-    )
-    .parse()
-    .unwrap()
+    let generated = match marigold_parse(&s) {
+        Ok(code) => code,
+        Err(e) => {
+            let msg = format!("marigold parsing error: {e}");
+            let span = Span::call_site();
+            return quote_spanned!(span=> compile_error!(#msg);).into();
+        }
+    };
+    format!("{{\n{generated}\n}}\n")
+        .parse()
+        .unwrap_or_else(|e| panic!("marigold codegen produced invalid tokens: {e}"))
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Replace `.expect("marigold parsing error")` with a `match` that returns a `compile_error!` token stream on parse failure, attaching the error to `proc_macro2::Span::call_site()` so it points at the macro invocation site in user code.
- Replace `.parse().unwrap()` with `.parse().unwrap_or_else(|e| panic!("marigold codegen produced invalid tokens: {e}"))` to give a clear, actionable message if the macro ever emits malformed tokens (an internal invariant violation).
- Add `proc-macro2 = "1"` and `quote = "1"` to `marigold-macros/Cargo.toml` to support `quote_spanned!` and `Span::call_site()`.

## Motivation

Previously, any syntax error in a `marigold!` invocation would produce an opaque `panicked at 'marigold parsing error'` message with no source location. With this fix, `rustc` reports a proper `error[E0]` pointing directly at the offending `marigold!(...)` call, matching the behaviour users expect from procedural macros.

## Test plan

- [ ] Trigger a deliberate parse error inside a `marigold!` invocation (e.g. invalid syntax) and confirm `rustc` emits `error: marigold parsing error: ...` pointing at the macro call site instead of a panic.
- [ ] Verify the existing test suite (`cargo test --workspace`) continues to pass.
- [ ] Confirm `cargo check --workspace` succeeds with the new `proc-macro2` / `quote` dependencies resolved.
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_011LYFrHwghQBPNBWVeVhvjd)_