### PR TITLE
fix(marigold): remove const from generated fn declarations — const fn restrictions break non-trivial user functions

### DIFF
--- a/marigold-grammar/src/nodes.rs
+++ b/marigold-grammar/src/nodes.rs
@@ -734,7 +734,7 @@ impl FnDeclarationNode {
         let output_type = &self.output_type;
         let body = &self.body;
 
-        format!("const fn {name}({parameters_string}) -> {output_type} {{{body}}}")
+        format!("fn {name}({parameters_string}) -> {output_type} {{{body}}}")
     }
 }
 


### PR DESCRIPTION
## Summary

- `FnDeclarationNode::code()` in `marigold-grammar/src/nodes.rs` was emitting `const fn {name}(...)` for every user-defined function.
- `const fn` in Rust prohibits heap allocations, closures, most trait method calls, and async code — so any non-trivial user function body would produce a confusing compile error in the generated code.
- The marigold architecture makes no claim that user functions must be `const`, so this was an accidental over-restriction.
- Fix: changed the single `format!` call to emit `fn {name}(...)` instead of `const fn {name}(...)`.

## Test plan

- [ ] Verify `marigold-grammar` unit tests still pass (`cargo test -p marigold-grammar`)
- [ ] Write a marigold program with a user-defined function that performs a heap allocation (e.g. returns a `Vec` or `String`) and confirm it compiles without error on this branch
- [ ] Confirm trivial functions (no heap allocs, no closures) still compile correctly

https://claude.ai/code/session_011LYFrHwghQBPNBWVeVhvjd

---
_Generated by [Claude Code](https://claude.ai/code/session_011LYFrHwghQBPNBWVeVhvjd)_