### PR TITLE
arch: drop dead extern crate proc_macro and trivial it_works test in marigold-grammar

### DIFF
--- a/marigold-grammar/src/lib.rs
+++ b/marigold-grammar/src/lib.rs
@@ -62,8 +62,6 @@
 //! - **Code generation**: Dominates runtime, scales with program complexity
 //! - **Binary size**: Pest parser adds ~40KB to binary size
 
-extern crate proc_macro;
-
 pub use itertools;
 
 pub mod bound_resolution;
@@ -96,13 +94,4 @@ pub fn marigold_analyze(
     s: &str,
 ) -> Result<complexity::ProgramComplexity, parser::MarigoldParseError> {
     parser::PestParser::analyze(s)
-}
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 4);
-    }
 }


### PR DESCRIPTION
## Concern (one per PR)

Dead code / no-signal test inside `marigold-grammar/src/lib.rs`.

## Findings

1. `extern crate proc_macro;` — `marigold-grammar` is a regular library crate (declares `pest_derive` as a dependency, not a `proc-macro` target in `Cargo.toml`). Nothing in this crate names `proc_macro::*`, so the declaration only makes the implicit prelude crate visible without anyone using it. The only legitimate occurrence is in `marigold-macros/src/lib.rs`, which is the actual `[lib] proc-macro = true` crate.
2. `mod tests { fn it_works() { let result = 2 + 2; assert_eq!(result, 4); } }` — asserts nothing about the crate under test; it is the canonical `cargo new --lib` placeholder.

## Cited rule

Dead-code / unused-import hygiene (in spirit of `clippy::useless_extern_crate`, `dead_code`): remove code that has no behavioural effect and tests that exercise no production code path. Both reduce LOC and noise without altering behaviour.

## Diff

`marigold-grammar/src/lib.rs`: -11 LOC, no production behaviour change.

## Verification

- `cargo check -p marigold-grammar`: clean.
- `cargo test -p marigold-grammar --lib`: 294 passed; 0 failed (was 295 — the removed test is the only delta).

Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01FHpjzuhbpP6qZkEmkmogja)_