### PR TITLE
test(type_aggregation): cover absorbing/identity invariants

### DIFF
--- a/marigold-grammar/src/type_aggregation.rs
+++ b/marigold-grammar/src/type_aggregation.rs
@@ -26,3 +26,152 @@ pub fn aggregate_input_count<I: IntoIterator<Item = nodes::InputCount>>(
     }
     nodes::InputCount::Known(total_count)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::nodes::{InputCount, InputVariability};
+    use num_bigint::BigUint;
+
+    // ---- aggregate_input_variability invariants ----
+
+    /// Empty iterator is the identity element: aggregating nothing is `Constant`.
+    /// (Constant is the absorbing-by-absence default; only `Variable` "taints".)
+    #[test]
+    fn variability_empty_is_constant() {
+        let out = aggregate_input_variability(std::iter::empty());
+        assert!(matches!(out, InputVariability::Constant));
+    }
+
+    /// Single `Constant` input stays `Constant`.
+    #[test]
+    fn variability_single_constant_is_constant() {
+        let out = aggregate_input_variability([InputVariability::Constant]);
+        assert!(matches!(out, InputVariability::Constant));
+    }
+
+    /// Single `Variable` input promotes the result.
+    #[test]
+    fn variability_single_variable_is_variable() {
+        let out = aggregate_input_variability([InputVariability::Variable]);
+        assert!(matches!(out, InputVariability::Variable));
+    }
+
+    /// `Variable` is absorbing: any `Variable` in the input produces `Variable`,
+    /// regardless of position or count of `Constant`s around it.
+    #[test]
+    fn variability_variable_is_absorbing() {
+        let out = aggregate_input_variability([
+            InputVariability::Constant,
+            InputVariability::Constant,
+            InputVariability::Variable,
+            InputVariability::Constant,
+        ]);
+        assert!(matches!(out, InputVariability::Variable));
+    }
+
+    /// Aggregating only `Constant`s yields `Constant`.
+    #[test]
+    fn variability_all_constant_is_constant() {
+        let out = aggregate_input_variability([
+            InputVariability::Constant,
+            InputVariability::Constant,
+            InputVariability::Constant,
+        ]);
+        assert!(matches!(out, InputVariability::Constant));
+    }
+
+    // ---- aggregate_input_count invariants ----
+
+    /// Empty iterator sums to `Known(0)` — additive identity.
+    #[test]
+    fn count_empty_is_known_zero() {
+        let out = aggregate_input_count(std::iter::empty());
+        match out {
+            InputCount::Known(n) => assert_eq!(n, BigUint::from(0u32)),
+            other => panic!("expected Known(0), got {:?}", debug_kind(&other)),
+        }
+    }
+
+    /// Sum of `Known` values is the BigUint sum.
+    #[test]
+    fn count_sums_known_values() {
+        let out = aggregate_input_count([
+            InputCount::Known(BigUint::from(10u32)),
+            InputCount::Known(BigUint::from(20u32)),
+            InputCount::Known(BigUint::from(7u32)),
+        ]);
+        match out {
+            InputCount::Known(n) => assert_eq!(n, BigUint::from(37u32)),
+            other => panic!("expected Known(37), got {:?}", debug_kind(&other)),
+        }
+    }
+
+    /// Sums above u64::MAX must not overflow — BigUint must be honoured.
+    #[test]
+    fn count_sums_handle_large_values() {
+        let big = BigUint::from(u64::MAX);
+        let out = aggregate_input_count([
+            InputCount::Known(big.clone()),
+            InputCount::Known(big.clone()),
+        ]);
+        match out {
+            InputCount::Known(n) => assert_eq!(n, &big + &big),
+            other => panic!("expected Known(2*u64::MAX), got {:?}", debug_kind(&other)),
+        }
+    }
+
+    /// `Unknown` short-circuits to `Unknown`, even mixed with valid `Known`s.
+    #[test]
+    fn count_unknown_short_circuits() {
+        let out = aggregate_input_count([
+            InputCount::Known(BigUint::from(5u32)),
+            InputCount::Unknown,
+            InputCount::Known(BigUint::from(99u32)),
+        ]);
+        assert!(matches!(out, InputCount::Unknown));
+    }
+
+    /// Unresolved `Enum` placeholders also short-circuit to `Unknown`
+    /// — guarding against silently emitting incorrect cardinalities when
+    /// enum-range resolution has not yet run.
+    #[test]
+    fn count_enum_short_circuits() {
+        let out = aggregate_input_count([
+            InputCount::Known(BigUint::from(5u32)),
+            InputCount::Enum("MyEnum".to_string()),
+        ]);
+        assert!(matches!(out, InputCount::Unknown));
+    }
+
+    /// Short-circuit must trigger on the first `Unknown`/`Enum` and not be
+    /// "rescued" by later `Known` entries — `Unknown` is absorbing.
+    #[test]
+    fn count_unknown_first_remains_unknown() {
+        let out = aggregate_input_count([
+            InputCount::Unknown,
+            InputCount::Known(BigUint::from(1u32)),
+            InputCount::Known(BigUint::from(2u32)),
+        ]);
+        assert!(matches!(out, InputCount::Unknown));
+    }
+
+    /// Single `Known(n)` round-trips to `Known(n)`.
+    #[test]
+    fn count_single_known_passes_through() {
+        let out = aggregate_input_count([InputCount::Known(BigUint::from(42u32))]);
+        match out {
+            InputCount::Known(n) => assert_eq!(n, BigUint::from(42u32)),
+            other => panic!("expected Known(42), got {:?}", debug_kind(&other)),
+        }
+    }
+
+    // Small helper since InputCount does not derive Debug.
+    fn debug_kind(c: &InputCount) -> &'static str {
+        match c {
+            InputCount::Known(_) => "Known",
+            InputCount::Enum(_) => "Enum",
+            InputCount::Unknown => "Unknown",
+        }
+    }
+}


### PR DESCRIPTION
## Component

`marigold-grammar/src/type_aggregation.rs`:
- `aggregate_input_variability(I) -> InputVariability`
- `aggregate_input_count(I) -> InputCount`

## Disposition (gap)

These are the algebraic primitives behind every cardinality figure produced by `marigold_analyze`. The only existing coverage was e2e via `tests/type_aggregation_tests.rs` (3 tests: a single-range cardinality, a chained map, and one `select_all` sum). That suite exercises only the happy `Known + Known` path on a `Vec`-shaped input and never reaches the `Unknown` short-circuit, the unresolved `Enum` short-circuit, the empty-iterator identity case, or the BigUint > u64 case. A regression in either function would silently corrupt complexity output. The right test type here is direct unit tests at the function boundary — fast, deterministic, and pinned to the algebraic laws (no parser plumbing needed).

## Invariants pinned

`aggregate_input_variability`:
- empty iterator -> `Constant` (identity element).
- single `Constant` -> `Constant`.
- single `Variable` -> `Variable`.
- `Variable` is absorbing — any occurrence promotes the result regardless of position.
- all-`Constant` input -> `Constant`.

`aggregate_input_count`:
- empty iterator -> `Known(0)` (additive identity).
- sum over `Known(n_i)` is the BigUint sum of `n_i`.
- sums above `u64::MAX` are preserved (no overflow — BigUint honoured).
- `Unknown` short-circuits to `Unknown`, even when interleaved with `Known`s.
- unresolved `Enum(_)` placeholders short-circuit to `Unknown` (guards against silent miscomputation if enum-range resolution has not run).
- short-circuit is sticky: leading `Unknown` stays `Unknown` regardless of trailing `Known` values.
- single `Known(n)` round-trips to `Known(n)`.

## Verification

`cargo test -p marigold-grammar --lib type_aggregation`: 12 passed; 0 failed.
Full lib suite: 295 -> 307 (12 new), 0 failed.

## CI status

CI is push-triggered on this repo (`tests.yaml`, `style.yaml`); will run automatically on the pushed branch. Iteration budget: 2.

Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01FHpjzuhbpP6qZkEmkmogja)_