### PR TITLE
arch: remove vacuous it_works placeholder test

### DIFF
--- a/marigold-grammar/src/lib.rs
+++ b/marigold-grammar/src/lib.rs
@@ -97,12 +97,3 @@ pub fn marigold_analyze(
 ) -> Result<complexity::ProgramComplexity, parser::MarigoldParseError> {
     parser::PestParser::analyze(s)
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 4);
-    }
-}


### PR DESCRIPTION
## Summary

`marigold-grammar/src/lib.rs` contained a leftover `cargo new` template test asserting `2 + 2 == 4`. It exercises nothing in the crate and is pure scaffolding.

## Precept

The library docstring states "the parser implementation is validated through Unit tests in each module covering specific functionality." A test that asserts a constant arithmetic identity is not validation; it is dead code. Removing it reduces lines and clarifies intent.

## Test plan

- [ ] `cargo test -p marigold-grammar`

https://claude.ai/code/session_01P4jqYEaszguJ91VUxtR3XV

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4jqYEaszguJ91VUxtR3XV)_