### PR TITLE
test: add coverage for multi_consumer_stream and writer modules

### DIFF
--- a/marigold-impl/tests/multi_consumer_stream_tests.rs
+++ b/marigold-impl/tests/multi_consumer_stream_tests.rs
@@ -1,0 +1,52 @@
+use futures::{Stream, StreamExt};
+use marigold_impl::multi_consumer_stream::{MultiConsumerStream, RunFutureAsStream};
+
+#[tokio::test]
+async fn run_future_as_stream_produces_no_items() {
+    let stream: RunFutureAsStream<u32, (), _> = RunFutureAsStream::new(Box::pin(async { () }));
+    let results: Vec<u32> = stream.collect().await;
+    assert!(results.is_empty());
+}
+
+#[test]
+fn run_future_as_stream_size_hint() {
+    let stream: RunFutureAsStream<u32, (), _> = RunFutureAsStream::new(Box::pin(async { () }));
+    assert_eq!(stream.size_hint(), (0, None));
+}
+
+#[tokio::test]
+async fn multi_consumer_empty_stream_no_consumers() {
+    let mcs = MultiConsumerStream::new(futures::stream::iter(Vec::<u32>::new()));
+    mcs.run().await;
+}
+
+#[tokio::test]
+async fn multi_consumer_empty_stream_with_consumer() {
+    let mut mcs = MultiConsumerStream::new(futures::stream::iter(Vec::<u32>::new()));
+    let rx = mcs.get();
+    mcs.run().await;
+    let results: Vec<u32> = rx.collect().await;
+    assert!(results.is_empty());
+}
+
+#[tokio::test]
+async fn multi_consumer_single_consumer_gets_all_items() {
+    let mut mcs = MultiConsumerStream::new(futures::stream::iter(vec![1u32, 2, 3]));
+    let rx = mcs.get();
+    // Use tokio::spawn so the run loop is concurrent with the collect, avoiding
+    // the deadlock that would occur when BUFFER_SIZE=1 without a runtime spawn.
+    tokio::spawn(mcs.run());
+    let results: Vec<u32> = rx.collect().await;
+    assert_eq!(results, vec![1, 2, 3]);
+}
+
+#[tokio::test]
+async fn multi_consumer_two_consumers_each_get_all_items() {
+    let mut mcs = MultiConsumerStream::new(futures::stream::iter(vec![10u32, 20, 30]));
+    let rx1 = mcs.get();
+    let rx2 = mcs.get();
+    tokio::spawn(mcs.run());
+    let (r1, r2) = tokio::join!(rx1.collect::<Vec<_>>(), rx2.collect::<Vec<_>>());
+    assert_eq!(r1, vec![10, 20, 30]);
+    assert_eq!(r2, vec![10, 20, 30]);
+}

--- a/marigold-impl/tests/writer_tests.rs
+++ b/marigold-impl/tests/writer_tests.rs
@@ -1,0 +1,59 @@
+#[cfg(feature = "io")]
+mod tests {
+    use marigold_impl::writer::Writer;
+    use tokio::io::AsyncWriteExt;
+
+    #[tokio::test]
+    async fn vector_writer_write_and_flush() {
+        let mut w = Writer::vector();
+        w.write_all(b"hello world").await.unwrap();
+        w.flush().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn vector_writer_shutdown() {
+        let mut w = Writer::vector();
+        w.write_all(b"data").await.unwrap();
+        w.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn vector_writer_sequential_writes() {
+        let mut w = Writer::vector();
+        w.write_all(b"chunk1").await.unwrap();
+        w.write_all(b"chunk2").await.unwrap();
+        w.flush().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn file_writer_write_and_flush() {
+        let path = std::env::temp_dir().join(format!(
+            "marigold_writer_test_{}.bin",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .subsec_nanos()
+        ));
+        let file = tokio::fs::File::create(&path).await.unwrap();
+        let mut w = Writer::file(file);
+        w.write_all(b"test data").await.unwrap();
+        w.flush().await.unwrap();
+        let _ = tokio::fs::remove_file(&path).await;
+    }
+
+    #[tokio::test]
+    async fn file_writer_shutdown() {
+        let path = std::env::temp_dir().join(format!(
+            "marigold_writer_shutdown_{}.bin",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .subsec_nanos()
+        ));
+        let file = tokio::fs::File::create(&path).await.unwrap();
+        let mut w = Writer::file(file);
+        w.write_all(b"shutdown test").await.unwrap();
+        w.shutdown().await.unwrap();
+        let _ = tokio::fs::remove_file(&path).await;
+    }
+}


### PR DESCRIPTION
## Summary

- **`marigold-impl/tests/multi_consumer_stream_tests.rs`** (new): tests `MultiConsumerStream` (empty stream, single consumer, two consumers) and `RunFutureAsStream` (no items produced, `size_hint`). Multi-item tests use `tokio::spawn(mcs.run())` to keep the send loop concurrent with the collect, avoiding the BUFFER_SIZE=1 deadlock on the no-feature inline path.
- **`marigold-impl/tests/writer_tests.rs`** (new): tests `Writer::vector()` and `Writer::file()` for `write_all`, `flush`, and `shutdown` — all gated on `#[cfg(feature = "io")]` since the module only exists with that feature.

## Test plan

- [ ] `cargo test -p marigold-impl` (no features) — 6 new tests pass
- [ ] `cargo test -p marigold-impl --features tokio,io` — all tests including writer pass
- [ ] `cargo test -p marigold-impl --features async-std` — all tests pass
- [ ] CI passes on this branch (all five feature combinations in the workflow)

https://claude.ai/code/session_018eSpdWVpRSeSuDnaaUTKtA

---
_Generated by [Claude Code](https://claude.ai/code/session_018eSpdWVpRSeSuDnaaUTKtA)_