### PR TITLE
arch: dedupe MultiConsumerStream::run cfg branches

### DIFF
--- a/marigold-impl/src/multi_consumer_stream.rs
+++ b/marigold-impl/src/multi_consumer_stream.rs
@@ -41,8 +41,7 @@ impl<
     pub async fn run(mut self) {
         self.senders.shrink_to_fit();
 
-        #[cfg(any(feature = "async-std", feature = "tokio"))]
-        crate::async_runtime::spawn(async move {
+        let task = async move {
             while let Some(v) = self.inner_stream.next().await {
                 let mut futures = self
                     .senders
@@ -52,20 +51,13 @@ impl<
                 while let Some(_result) = futures.next().await {}
             }
             self.senders.iter_mut().for_each(|s| s.disconnect());
-        });
+        };
+
+        #[cfg(any(feature = "async-std", feature = "tokio"))]
+        crate::async_runtime::spawn(task);
 
         #[cfg(not(any(feature = "async-std", feature = "tokio")))]
-        {
-            while let Some(v) = self.inner_stream.next().await {
-                let mut futures = self
-                    .senders
-                    .iter_mut()
-                    .map(|sender| sender.feed(v))
-                    .collect::<FuturesUnordered<_>>();
-                while let Some(_result) = futures.next().await {}
-            }
-            self.senders.iter_mut().for_each(|s| s.disconnect());
-        }
+        task.await;
     }
 }
 


### PR DESCRIPTION
## Summary

`MultiConsumerStream::run` in `marigold-impl/src/multi_consumer_stream.rs` carried two cfg branches whose loop bodies were byte-for-byte identical; the only meaningful difference was whether the work was wrapped in `crate::async_runtime::spawn(...)` (when `tokio`/`async-std` is enabled) or awaited inline.

Hoist the common body into a single `task` async block, then let the cfg gate select between `crate::async_runtime::spawn(task)` and `task.await`. Net change is **-8 LOC** with zero behaviour difference: in the runtime-enabled build, the spawn boundary still encloses exactly the same future; in the no-runtime build, the future is still driven by the caller's `await` on `run`.

## Why this is non-speculative

- No new abstraction, no new helper function, no new generic, no behaviour shift.
- The two branches were a copy-paste — collapsing them is the most direct way to remove redundancy.
- Other open arch PRs (#218, #221) target unrelated dead code (`bound_expr.rs`); this change does not overlap.

## Constraints respected

- No tests touched (only the production body of `run`).
- No docs touched.

## Verification

Run locally on this branch from the worktree:

- `cargo build -p marigold-impl`              (no-default-features) — clean
- `cargo build -p marigold-impl --features tokio` — clean
- `cargo test  -p marigold-impl`              (no-default-features) — 28 + 4 + 5 + 7 + 4 + 8 passed, 0 failed
- `cargo test  -p marigold-impl --features tokio` — same: all green
- `cargo clippy -p marigold-impl -- -D warnings` — clean
- `cargo clippy -p marigold-impl --features tokio -- -D warnings` — clean
- `cargo fmt --check` — clean

## Test plan

- [ ] CI `tests` workflow green
- [ ] CI `style` workflow green
- [ ] CI `wasm` workflow green (no-runtime cfg path)

https://claude.ai/code/session_011C3Q2no7XQp7MfxDcEEhDT

---
_Generated by [Claude Code](https://claude.ai/code/session_011C3Q2no7XQp7MfxDcEEhDT)_