### PR TITLE
docs: tighten grammar lib doc and fix typo in keep_first_n

### DIFF
--- a/marigold-grammar/src/lib.rs
+++ b/marigold-grammar/src/lib.rs
@@ -2,20 +2,11 @@
 
 //! # Marigold Grammar Library
 //!
-//! This crate provides the grammar and parser infrastructure for the Marigold DSL.
-//!
-//! ## Overview
-//!
-//! Marigold is a domain-specific language for expressing stream processing programs in Rust.
-//! This library provides:
-//!
-//! - **Pest-based parser**: Fast, maintainable PEG parser
-//! - **AST definitions**: Complete abstract syntax tree for Marigold programs
-//! - **Code generation**: Transforms Marigold programs into valid Rust code
+//! Grammar and parser infrastructure for the Marigold DSL: a Pest-based PEG
+//! parser, AST definitions, and code generation that turns Marigold programs
+//! into valid Rust.
 //!
 //! ## Quick Start
-//!
-//! Parse a Marigold program:
 //!
 //! ```ignore
 //! use marigold_grammar::parser::parse_marigold;
@@ -26,41 +17,26 @@
 //!
 //! ## Architecture
 //!
-//! ### Parser
+//! - [`parser`]: Pest-based parser behind a trait abstraction; use
+//!   [`parser::get_parser()`] for an instance.
+//! - [`nodes`]: AST node definitions for all Marigold constructs.
+//! - [`pest_ast_builder`]: Transforms Pest parse trees into the AST.
+//! - `src/marigold.pest`: the grammar file.
 //!
-//! The [`parser`] module provides the Pest-based parser with a trait abstraction
-//! for extensibility. The factory function [`parser::get_parser()`] returns a
-//! parser instance.
+//! Code generation is performed by an internal function that transforms the
+//! AST to Rust source.
 //!
-//! ### Grammar File
+//! ## Performance
 //!
-//! - **Pest**: `src/marigold.pest` - Defines the complete Marigold language grammar
-//!
-//! ### AST and Code Generation
-//!
-//! - [`nodes`]: AST node definitions for all Marigold constructs
-//! - Code generation: Internal function that transforms AST to Rust code
-//! - [`pest_ast_builder`]: Transforms Pest parse trees into the AST
-//!
-//! ## Testing & Validation
-//!
-//! The parser implementation is validated through:
-//!
-//! - **Unit tests** in each module covering specific functionality
-//! - **Negative tests** ensuring invalid syntax is properly rejected
-//! - **Integration tests** using real-world example programs
+//! - Parsing: < 1ms for typical programs.
+//! - Code generation: dominates runtime; scales with program complexity.
+//! - Binary size: Pest parser adds ~40KB.
 //!
 //! ## Feature Flags
 //!
-//! - `io`: I/O features (available in other crates)
-//! - `tokio`: Tokio runtime integration (available in other crates)
-//! - `async-std`: async-std runtime integration (available in other crates)
-//!
-//! ## Performance Characteristics
-//!
-//! - **Parsing**: Completes in < 1ms for typical programs
-//! - **Code generation**: Dominates runtime, scales with program complexity
-//! - **Binary size**: Pest parser adds ~40KB to binary size
+//! `io`, `tokio`, and `async-std` are declared for workspace coordination but
+//! gate no functionality in this crate; the corresponding behaviour lives in
+//! sibling crates.
 
 extern crate proc_macro;
 
@@ -75,10 +51,9 @@ mod type_aggregation;
 
 pub mod pest_ast_builder;
 
-/// Convenience function for parsing Marigold code
+/// Parse a Marigold program and return generated Rust code.
 ///
-/// This is an alias for [`parser::parse_marigold`] that uses the appropriate parser
-/// based on feature flags. It's the recommended entry point for most use cases.
+/// Recommended entry point; thin alias for [`parser::parse_marigold`].
 ///
 /// # Examples
 ///

--- a/marigold-impl/src/keep_first_n.rs
+++ b/marigold-impl/src/keep_first_n.rs
@@ -46,7 +46,7 @@ where
 }
 
 /// Internal logic for keep_first_n. This is in a separate function so that we can get the full
-/// type of the binary heap, which includes a lambda for reversing the ordering fromt the passed
+/// type of the binary heap, which includes a lambda for reversing the ordering from the passed
 /// sort_by function. By declaring a new function, we can use generics to describe its type, and
 /// then can use that type while unsafely casting pointers.
 ///


### PR DESCRIPTION
## Summary

Conservative clarity pass over docs and code comments, no logic or test changes.

- `marigold-grammar/src/lib.rs`: condensed the crate-level rustdoc — collapsed redundant overview/quick-start phrasing, dropped bullets that merely restated the per-module list, refreshed the `marigold_parse` doc, and clarified that the `io` / `tokio` / `async-std` features are declared for workspace coordination only (they gate no functionality in this crate).
- `marigold-impl/src/keep_first_n.rs`: fixed typo `fromt` -> `from` in the `impl_keep_first_n` doc comment.

No code-pointer or date-format inconsistencies were found in the repo, so no standardization beyond the above was needed. Existing rustdoc-style references (`[`module`]`, backticked paths) and absence of dates were already consistent.

Note: the designated base branch `claude/awesome-fermat-SUJ4S` does not exist on the remote, so this PR targets `main`.

## Test plan

- [x] `cargo check --workspace --all-features` passes.
- [x] `cargo doc -p marigold-grammar --no-deps` builds clean.
- [x] `cargo fmt --all -- --check` passes.
- [ ] CI green on push.

---
_Generated by [Claude Code](https://claude.ai/code/session_011C3Q2no7XQp7MfxDcEEhDT)_