### PR TITLE
cron(test): cover multi_consumer_stream fan-out and runner invariants

### DIFF
--- a/marigold-impl/tests/multi_consumer_stream_edge_cases.rs
+++ b/marigold-impl/tests/multi_consumer_stream_edge_cases.rs
@@ -1,0 +1,51 @@
+use futures::stream::StreamExt;
+use marigold_impl::multi_consumer_stream::{MultiConsumerStream, RunFutureAsStream};
+
+#[tokio::test]
+async fn fans_out_every_value_to_every_consumer() {
+    let mut mcs = MultiConsumerStream::new(futures::stream::iter(0_u32..5));
+    let a = mcs.get();
+    let b = mcs.get();
+    let c = mcs.get();
+
+    let runner = mcs.run();
+
+    let (a, b, c, _) = futures::join!(
+        a.collect::<Vec<_>>(),
+        b.collect::<Vec<_>>(),
+        c.collect::<Vec<_>>(),
+        runner,
+    );
+
+    let expected: Vec<u32> = (0..5).collect();
+    assert_eq!(a, expected);
+    assert_eq!(b, expected);
+    assert_eq!(c, expected);
+}
+
+#[tokio::test]
+async fn empty_inner_yields_empty_consumer_streams() {
+    let mut mcs = MultiConsumerStream::new(futures::stream::iter(Vec::<i32>::new()));
+    let only = mcs.get();
+
+    let (collected, _) = futures::join!(only.collect::<Vec<i32>>(), mcs.run());
+    assert!(collected.is_empty());
+}
+
+#[tokio::test]
+async fn no_consumers_drains_inner_stream() {
+    // Even with zero consumers, run() must complete (and not deadlock) once the
+    // inner stream is exhausted.
+    let mcs = MultiConsumerStream::new(futures::stream::iter(0_u8..3));
+    mcs.run().await;
+}
+
+#[tokio::test]
+async fn run_future_as_stream_terminates_when_future_resolves() {
+    let fut = Box::pin(async { 7_i32 });
+    let s: RunFutureAsStream<i32, i32, _> = RunFutureAsStream::new(fut);
+    // The stream itself never yields T values; it ends as soon as the wrapped
+    // future resolves. Collect should produce an empty Vec.
+    let collected: Vec<i32> = s.collect().await;
+    assert!(collected.is_empty());
+}


### PR DESCRIPTION
## Why

`marigold-impl/src/multi_consumer_stream.rs` had no unit or integration tests in `marigold-impl` despite being load-bearing in code generation. `MultiConsumerStream` and `RunFutureAsStream` are referenced from [`marigold-grammar/src/nodes.rs`](marigold-grammar/src/nodes.rs) (lines 201, 209, 238, 246) for stream-variable declarations and runners. Coverage today comes only indirectly via integration / example programs.

## Changes

New test file [`marigold-impl/tests/multi_consumer_stream_edge_cases.rs`](marigold-impl/tests/multi_consumer_stream_edge_cases.rs) covering four invariants:

- **fan-out**: every consumer obtained via `get()` receives every value from the inner stream.
- **empty-inner**: a consumer attached to an empty stream collects nothing.
- **zero-consumers**: `run()` drains the inner stream and returns even when no consumers attached (no deadlock).
- **runner**: `RunFutureAsStream` yields no `T` values and ends as soon as its wrapped future resolves.

## Verification

- `cargo test -p marigold-impl --test multi_consumer_stream_edge_cases` — 4/4 pass.
- `cargo test -p marigold-impl --features tokio --test multi_consumer_stream_edge_cases` — 4/4 pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_014Wsc8JzCphZKZAtzDF4fuK)_