### PR TITLE
arch(grammar): drop unused itertools dep, demote serde_json to dev-dep

### DIFF
--- a/marigold-grammar/Cargo.toml
+++ b/marigold-grammar/Cargo.toml
@@ -15,17 +15,16 @@ async-std = []
 
 [dependencies]
 num-traits = "0.2"
-itertools = "0.10.2"
 num-bigint = "0.4"
 arrayvec = "0.7"
 pest = "2.7"
 pest_derive = "2.7"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 proptest = "1"
+serde_json = "1"
 tempfile = "3"
 
 [[bench]]

--- a/marigold-grammar/src/lib.rs
+++ b/marigold-grammar/src/lib.rs
@@ -64,8 +64,6 @@
 
 extern crate proc_macro;
 
-pub use itertools;
-
 pub mod bound_resolution;
 pub mod complexity;
 pub mod nodes;


### PR DESCRIPTION
## Summary

- `marigold-grammar` declares `itertools` and re-exports it via `pub use itertools;` in `lib.rs`, but nothing in this crate (or any consumer reachable via `marigold_grammar::itertools`) uses it. Drop the re-export and the dependency.
- `serde_json` is only referenced inside `#[cfg(test)] mod tests` blocks in `complexity.rs` (16 occurrences, all test-only). Move it from `[dependencies]` to `[dev-dependencies]`.

Net effect: smaller dependency graph and faster compile for downstream users; no public API change for any *used* re-export.

## Verification

- `cargo check -p marigold-grammar` and `cargo check -p marigold-grammar --tests` both succeed locally on this branch.
- `grep -rn 'marigold_grammar::itertools'` over the repo returns no hits.
- All `serde_json::` references in `marigold-grammar/src/complexity.rs` are inside `#[cfg(test)] mod tests` blocks (line 1075-onward).

## Test plan

- [ ] CI build / lint passes
- [ ] CI tests pass (the dev-dep move is the only thing that could break tests; `serde_json` is still available there)

https://claude.ai/code/session_01P7Gyqbvjmf2pCLpVYXH6N6

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7Gyqbvjmf2pCLpVYXH6N6)_