### PR TITLE
arch(impl): drop unused `pub use std::cmp::Ordering` re-export

### DIFF
--- a/marigold-impl/src/lib.rs
+++ b/marigold-impl/src/lib.rs
@@ -1,7 +1,6 @@
 #![forbid(unsafe_code)]
 
 pub use futures;
-pub use std::cmp::Ordering;
 mod async_runtime;
 pub mod collect_and_apply;
 pub mod combinations;


### PR DESCRIPTION
## Summary

`marigold-impl/src/lib.rs` re-exports `std::cmp::Ordering` at the crate root, but nothing in the workspace (or any downstream caller via `marigold::marigold_impl::Ordering`) uses it. Every consumer that needs `Ordering` imports `std::cmp::Ordering` directly (verified across `marigold-impl/benches/*.rs`, `marigold-grammar/src/complexity.rs`, etc.).

This is a minor architecture cleanup: trim a dead public re-export so the crate's surface accurately reflects what it offers.

## Verification

- `grep -rn 'marigold_impl::Ordering\|marigold::marigold_impl::Ordering'` returns zero hits.
- `cargo check --workspace --all-features` succeeds locally on this branch.

## Test plan

- [ ] CI build passes
- [ ] CI tests pass (no behavior change expected)

https://claude.ai/code/session_01P7Gyqbvjmf2pCLpVYXH6N6

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7Gyqbvjmf2pCLpVYXH6N6)_