### PR TITLE
docs: fix codecov badge target and tighten grammar module docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![lines of code](https://raw.githubusercontent.com/DominicBurkart/marigold/main/development_metadata/badges/lines_of_code.svg)](https://github.com/DominicBurkart/marigold)
 [![contributors](https://raw.githubusercontent.com/DominicBurkart/marigold/main/development_metadata/badges/contributors.svg)](https://github.com/DominicBurkart/marigold/graphs/contributors)
 [![bench](https://github.com/DominicBurkart/marigold/workflows/bench/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/bench.yaml)
-[![codecov](https://codecov.io/gh/DominicBurkart/nanna-coder/graph/badge.svg?token=47S7xzd3Ny)](https://codecov.io/gh/DominicBurkart/nanna-coder)
+[![codecov](https://codecov.io/gh/DominicBurkart/marigold/graph/badge.svg)](https://codecov.io/gh/DominicBurkart/marigold)
 [![tests](https://github.com/DominicBurkart/marigold/workflows/tests/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/tests.yaml)
 [![style](https://github.com/DominicBurkart/marigold/workflows/style/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/style.yaml)
 [![wasm](https://github.com/DominicBurkart/marigold/workflows/wasm/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/wasm.yaml)

--- a/marigold-grammar/src/lib.rs
+++ b/marigold-grammar/src/lib.rs
@@ -1,21 +1,9 @@
-#![forbid(unsafe_code)]
-
-//! # Marigold Grammar Library
+//! # Marigold Grammar
 //!
-//! This crate provides the grammar and parser infrastructure for the Marigold DSL.
-//!
-//! ## Overview
-//!
-//! Marigold is a domain-specific language for expressing stream processing programs in Rust.
-//! This library provides:
-//!
-//! - **Pest-based parser**: Fast, maintainable PEG parser
-//! - **AST definitions**: Complete abstract syntax tree for Marigold programs
-//! - **Code generation**: Transforms Marigold programs into valid Rust code
+//! Grammar, parser, and code generation for the Marigold DSL. Marigold is a
+//! domain-specific language for expressing stream processing programs in Rust.
 //!
 //! ## Quick Start
-//!
-//! Parse a Marigold program:
 //!
 //! ```ignore
 //! use marigold_grammar::parser::parse_marigold;
@@ -24,43 +12,18 @@
 //! println!("{}", code);
 //! ```
 //!
-//! ## Architecture
+//! ## Modules
 //!
-//! ### Parser
+//! - [`parser`]: PEG parser built on Pest. Use [`parser::get_parser()`] for an
+//!   instance, or [`parser::parse_marigold`] / [`marigold_parse`] for one-shot
+//!   parsing.
+//! - [`nodes`]: AST node definitions.
+//! - [`pest_ast_builder`]: Transforms Pest parse trees into the AST.
+//! - The grammar itself lives in `marigold-grammar/src/marigold.pest`.
 //!
-//! The [`parser`] module provides the Pest-based parser with a trait abstraction
-//! for extensibility. The factory function [`parser::get_parser()`] returns a
-//! parser instance.
-//!
-//! ### Grammar File
-//!
-//! - **Pest**: `src/marigold.pest` - Defines the complete Marigold language grammar
-//!
-//! ### AST and Code Generation
-//!
-//! - [`nodes`]: AST node definitions for all Marigold constructs
-//! - Code generation: Internal function that transforms AST to Rust code
-//! - [`pest_ast_builder`]: Transforms Pest parse trees into the AST
-//!
-//! ## Testing & Validation
-//!
-//! The parser implementation is validated through:
-//!
-//! - **Unit tests** in each module covering specific functionality
-//! - **Negative tests** ensuring invalid syntax is properly rejected
-//! - **Integration tests** using real-world example programs
-//!
-//! ## Feature Flags
-//!
-//! - `io`: I/O features (available in other crates)
-//! - `tokio`: Tokio runtime integration (available in other crates)
-//! - `async-std`: async-std runtime integration (available in other crates)
-//!
-//! ## Performance Characteristics
-//!
-//! - **Parsing**: Completes in < 1ms for typical programs
-//! - **Code generation**: Dominates runtime, scales with program complexity
-//! - **Binary size**: Pest parser adds ~40KB to binary size
+//! The parser is validated through unit tests, negative tests for invalid
+//! syntax, and integration tests using real example programs.
+#![forbid(unsafe_code)]
 
 extern crate proc_macro;
 
@@ -75,10 +38,9 @@ mod type_aggregation;
 
 pub mod pest_ast_builder;
 
-/// Convenience function for parsing Marigold code
+/// Parse a Marigold program and return the generated Rust code.
 ///
-/// This is an alias for [`parser::parse_marigold`] that uses the appropriate parser
-/// based on feature flags. It's the recommended entry point for most use cases.
+/// Alias for [`parser::parse_marigold`].
 ///
 /// # Examples
 ///
@@ -86,7 +48,6 @@ pub mod pest_ast_builder;
 /// use marigold_grammar::marigold_parse;
 ///
 /// let code = marigold_parse("range(0, 100).return")?;
-/// // code is now valid Rust code ready to compile
 /// ```
 pub fn marigold_parse(s: &str) -> Result<String, parser::MarigoldParseError> {
     parser::parse_marigold(s)

--- a/marigold-grammar/src/parser.rs
+++ b/marigold-grammar/src/parser.rs
@@ -1,21 +1,20 @@
-#![forbid(unsafe_code)]
-
-//! # Marigold Parser Module
+//! # Marigold Parser
 //!
-//! This module provides the Marigold parser using the Pest parsing library.
+//! Marigold parser built on the Pest parsing library.
 //!
-//! ## Usage Examples
+//! ## Usage
 //!
-//! Parse Marigold code:
+//! One-shot parse:
 //! ```ignore
 //! let result = parse_marigold("range(0, 1).return")?;
 //! ```
 //!
-//! Explicitly create a parser instance:
+//! Explicit parser instance:
 //! ```ignore
 //! let parser = PestParser::new();
 //! let result = parser.parse("range(0, 1).return")?;
 //! ```
+#![forbid(unsafe_code)]
 
 use pest::Parser;
 use std::fmt;

--- a/marigold/README.md
+++ b/marigold/README.md
@@ -6,7 +6,7 @@
 [![lines of code](https://raw.githubusercontent.com/DominicBurkart/marigold/main/development_metadata/badges/lines_of_code.svg)](https://github.com/DominicBurkart/marigold)
 [![contributors](https://raw.githubusercontent.com/DominicBurkart/marigold/main/development_metadata/badges/contributors.svg)](https://github.com/DominicBurkart/marigold/graphs/contributors)
 [![bench](https://github.com/DominicBurkart/marigold/workflows/bench/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/bench.yaml)
-[![codecov](https://codecov.io/gh/DominicBurkart/nanna-coder/graph/badge.svg?token=47S7xzd3Ny)](https://codecov.io/gh/DominicBurkart/nanna-coder)
+[![codecov](https://codecov.io/gh/DominicBurkart/marigold/graph/badge.svg)](https://codecov.io/gh/DominicBurkart/marigold)
 [![tests](https://github.com/DominicBurkart/marigold/workflows/tests/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/tests.yaml)
 [![style](https://github.com/DominicBurkart/marigold/workflows/style/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/style.yaml)
 [![wasm](https://github.com/DominicBurkart/marigold/workflows/wasm/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/wasm.yaml)


### PR DESCRIPTION
## Summary

Conservative documentation cleanup. Inventory found two README.md files (root and `marigold/README.md`) that are byte-identical, plus several Rust module-level doc comments in `marigold-grammar` with redundancy and a few inaccuracies.

## Changes

- **Codecov badge target fix** in `README.md:9` and `marigold/README.md:9`: badges currently point to an unrelated `DominicBurkart/nanna-coder` repository (with a stray token query string). Updated both to `DominicBurkart/marigold`. Outdated reference, breaks the rendered badge for this project.
- **`marigold-grammar/src/lib.rs`**: trimmed the module-level doc:
  - Collapsed the redundant `Overview` + `Architecture` sections into one `Modules` list — the bullets in `Overview` (Pest-based parser / AST definitions / Code generation) duplicated the per-module entries that followed.
  - Dropped the `Performance Characteristics` section. It cited unverified specifics (`< 1ms`, `~40KB`) that are not measured anywhere in the repo and would silently rot.
  - Dropped the `Feature Flags` section. The `io`, `tokio`, and `async-std` features in `marigold-grammar/Cargo.toml:11-14` are empty stubs forwarded from the umbrella crate; documenting them as "available in other crates" inside this crate's own docs is misleading.
  - Tightened the `marigold_parse` doc-comment (dropped the "recommended entry point" framing — the function is just an alias).
- **`marigold-grammar/src/lib.rs` and `marigold-grammar/src/parser.rs`**: moved `#![forbid(unsafe_code)]` to sit *after* the `//!` module doc-comment block, matching the convention already used in `marigold/src/lib.rs:25` and `marigold-impl/src/lib.rs:1`. Standardizes inner-attribute placement across the workspace.
- Renamed `# Marigold Grammar Library` to `# Marigold Grammar` and `# Marigold Parser Module` to `# Marigold Parser` (the "Library" / "Module" suffixes are redundant with the rustdoc rendering).

## Notes

- The two README.md files remain byte-identical duplicates. Keeping both is necessary so the published `marigold` crate has a README on crates.io while the repo root also has one. Did not consolidate (would require build-time symlink/sync setup, out of scope for a docs-clarity pass).
- Did not touch substantive content in any module docs — only verbose / redundant / outdated passages.
- Verified `cargo check -p marigold-grammar` passes locally after the edits.

## Test plan

- [ ] CI: `tests`, `style`, `wasm`, `bench` workflows pass
- [ ] `cargo doc --no-deps -p marigold-grammar` renders cleanly
- [ ] Codecov badge in both READMEs renders against the marigold project

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7Gyqbvjmf2pCLpVYXH6N6)_