### PR TITLE
test: cover MultiConsumerStream and Writer (zero-coverage modules)

### DIFF
--- a/marigold-impl/src/multi_consumer_stream.rs
+++ b/marigold-impl/src/multi_consumer_stream.rs
@@ -100,3 +100,70 @@ impl<T: std::marker::Send + Unpin + 'static, O, F: Future<Output = O>> Stream
         (0, None)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream::StreamExt;
+
+    #[tokio::test]
+    async fn multi_consumer_stream_no_consumers() {
+        let mcs = MultiConsumerStream::new(futures::stream::iter(vec![1u32, 2, 3]));
+        mcs.run().await;
+    }
+
+    #[tokio::test]
+    async fn multi_consumer_stream_single_consumer_receives_all() {
+        let mut mcs = MultiConsumerStream::new(futures::stream::iter(vec![1u32, 2, 3]));
+        let receiver = mcs.get();
+        let (_, items) = tokio::join!(mcs.run(), receiver.collect::<Vec<u32>>());
+        assert_eq!(items, vec![1, 2, 3]);
+    }
+
+    #[tokio::test]
+    async fn multi_consumer_stream_two_consumers_both_receive_all() {
+        let mut mcs = MultiConsumerStream::new(futures::stream::iter(vec![10u32, 20, 30]));
+        let receiver1 = mcs.get();
+        let receiver2 = mcs.get();
+        let (_, items1, items2) = tokio::join!(
+            mcs.run(),
+            receiver1.collect::<Vec<u32>>(),
+            receiver2.collect::<Vec<u32>>(),
+        );
+        assert_eq!(items1, vec![10, 20, 30]);
+        assert_eq!(items2, vec![10, 20, 30]);
+    }
+
+    #[tokio::test]
+    async fn multi_consumer_stream_empty_stream() {
+        let mut mcs = MultiConsumerStream::new(futures::stream::iter(Vec::<u32>::new()));
+        let receiver = mcs.get();
+        let (_, items) = tokio::join!(mcs.run(), receiver.collect::<Vec<u32>>());
+        assert!(items.is_empty());
+    }
+
+    #[tokio::test]
+    async fn multi_consumer_stream_single_item() {
+        let mut mcs = MultiConsumerStream::new(futures::stream::iter(vec![42u32]));
+        let receiver = mcs.get();
+        let (_, items) = tokio::join!(mcs.run(), receiver.collect::<Vec<u32>>());
+        assert_eq!(items, vec![42]);
+    }
+
+    #[tokio::test]
+    async fn run_future_as_stream_produces_no_items() {
+        let future = Box::pin(async { "side_effect_completed" });
+        let stream: RunFutureAsStream<u32, &str, _> = RunFutureAsStream::new(future);
+        let items: Vec<u32> = stream.collect().await;
+        assert!(items.is_empty());
+    }
+
+    #[tokio::test]
+    async fn run_future_as_stream_size_hint() {
+        let future = Box::pin(async { () });
+        let stream: RunFutureAsStream<u32, (), _> = RunFutureAsStream::new(future);
+        assert_eq!(stream.size_hint(), (0, None));
+        let items: Vec<u32> = stream.collect().await;
+        assert!(items.is_empty());
+    }
+}

--- a/marigold-impl/src/writer.rs
+++ b/marigold-impl/src/writer.rs
@@ -59,3 +59,38 @@ impl tokio::io::AsyncWrite for Writer {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::AsyncWriteExt;
+
+    #[tokio::test]
+    async fn writer_vector_write_and_flush() {
+        let mut writer = Writer::vector();
+        writer.write_all(b"hello world").await.unwrap();
+        writer.flush().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn writer_vector_shutdown_completes() {
+        let mut writer = Writer::vector();
+        writer.write_all(b"some data").await.unwrap();
+        writer.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn writer_vector_multiple_writes() {
+        let mut writer = Writer::vector();
+        writer.write_all(b"first ").await.unwrap();
+        writer.write_all(b"second").await.unwrap();
+        writer.flush().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn writer_vector_empty_write() {
+        let mut writer = Writer::vector();
+        writer.write_all(b"").await.unwrap();
+        writer.flush().await.unwrap();
+    }
+}


### PR DESCRIPTION
## Summary

Addresses the two largest untested modules in `marigold-impl` (both had 0% coverage per codecov):

- **`multi_consumer_stream.rs`** — 7 new unit tests covering `MultiConsumerStream` (no consumers, single consumer, two consumers, empty stream, single item) and `RunFutureAsStream` (no items emitted, size hint). Tests use `tokio::join!` to concurrently drive producer and consumer, avoiding the deadlock risk of `BUFFER_SIZE = 1` with the non-feature inline code path.
- **`writer.rs`** — 4 new unit tests covering the `Vector` variant of `AsyncWrite` (write + flush, shutdown, multiple sequential writes, empty write).

All tests are `#[tokio::test]` and use `tokio` from dev-dependencies, so they compile and run across every cargo test invocation (no-features, `--features tokio`, `--features async-std`, `--all-features`).

## Test plan
- [ ] `cargo test` (no features) — both modules compile and tests pass
- [ ] `cargo test --features tokio,io` — writer tests run; multi-consumer tests exercise the spawn path
- [ ] `cargo test --features tokio` — multi-consumer tests exercise the spawn path
- [ ] `cargo test --features async-std` — multi-consumer tests exercise the async-std spawn path
- [ ] `cargo test --all-features` — full coverage run
- [ ] codecov delta shows increased coverage for `multi_consumer_stream.rs` and `writer.rs`


---
_Generated by [Claude Code](https://claude.ai/code/session_01CzzytFc7uSgKLfQMQzTnGo)_