### PR TITLE
docs: fix stale codecov badge URL pointing to nanna-coder repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![lines of code](https://raw.githubusercontent.com/DominicBurkart/marigold/main/development_metadata/badges/lines_of_code.svg)](https://github.com/DominicBurkart/marigold)
 [![contributors](https://raw.githubusercontent.com/DominicBurkart/marigold/main/development_metadata/badges/contributors.svg)](https://github.com/DominicBurkart/marigold/graphs/contributors)
 [![bench](https://github.com/DominicBurkart/marigold/workflows/bench/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/bench.yaml)
-[![codecov](https://codecov.io/gh/DominicBurkart/nanna-coder/graph/badge.svg?token=47S7xzd3Ny)](https://codecov.io/gh/DominicBurkart/nanna-coder)
+[![codecov](https://codecov.io/gh/DominicBurkart/marigold/graph/badge.svg)](https://codecov.io/gh/DominicBurkart/marigold)
 [![tests](https://github.com/DominicBurkart/marigold/workflows/tests/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/tests.yaml)
 [![style](https://github.com/DominicBurkart/marigold/workflows/style/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/style.yaml)
 [![wasm](https://github.com/DominicBurkart/marigold/workflows/wasm/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/wasm.yaml)

--- a/marigold/README.md
+++ b/marigold/README.md
@@ -6,7 +6,7 @@
 [![lines of code](https://raw.githubusercontent.com/DominicBurkart/marigold/main/development_metadata/badges/lines_of_code.svg)](https://github.com/DominicBurkart/marigold)
 [![contributors](https://raw.githubusercontent.com/DominicBurkart/marigold/main/development_metadata/badges/contributors.svg)](https://github.com/DominicBurkart/marigold/graphs/contributors)
 [![bench](https://github.com/DominicBurkart/marigold/workflows/bench/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/bench.yaml)
-[![codecov](https://codecov.io/gh/DominicBurkart/nanna-coder/graph/badge.svg?token=47S7xzd3Ny)](https://codecov.io/gh/DominicBurkart/nanna-coder)
+[![codecov](https://codecov.io/gh/DominicBurkart/marigold/graph/badge.svg)](https://codecov.io/gh/DominicBurkart/marigold)
 [![tests](https://github.com/DominicBurkart/marigold/workflows/tests/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/tests.yaml)
 [![style](https://github.com/DominicBurkart/marigold/workflows/style/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/style.yaml)
 [![wasm](https://github.com/DominicBurkart/marigold/workflows/wasm/badge.svg)](https://github.com/DominicBurkart/marigold/actions/workflows/wasm.yaml)


### PR DESCRIPTION
## Summary

- The codecov badge in both `README.md` and `marigold/README.md` linked to `DominicBurkart/nanna-coder`, an unrelated repo. Repointed to `DominicBurkart/marigold` so badge image and click-through correspond to this project.
- Dropped the embedded `?token=...` query string; codecov badge URLs for public repos do not require an upload token, and including it in source is undesirable.

## Scope notes

- Conservative edits only. No structural changes, no style rewrites, no fragmentation.
- The two READMEs remain byte-identical (intentional duplication so crates.io serves the workspace README from `marigold/`).
- No other stale references, TODO/FIXME markers, or redundant doc passages found in top-level docs or scanned doc-comments.

## Test plan

- [ ] Verify rendered badge in `README.md` and `marigold/README.md` resolves to https://codecov.io/gh/DominicBurkart/marigold
- [ ] Confirm CI (style, tests, wasm) still passes — change is docs-only

https://claude.ai/code/session_014QXNr53WUnK5g2bLJkyE5E

---
_Generated by [Claude Code](https://claude.ai/code/session_014QXNr53WUnK5g2bLJkyE5E)_