### PR TITLE
arch: drop unused pin-utils dependency

### DIFF
--- a/marigold-impl/Cargo.toml
+++ b/marigold-impl/Cargo.toml
@@ -35,7 +35,6 @@ arrayvec = "0.7"
 flate2 = {version="1", optional=true}
 serde = {version="1", features=["derive"], optional=true}
 once_cell = "1.13.0"
-pin-utils = "0.1.0"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"]}


### PR DESCRIPTION
## Summary

`pin-utils = "0.1.0"` is declared in `marigold-impl/Cargo.toml` (line 38 on `main`) but no source file in the workspace imports it — `grep -rn pin_utils --include='*.rs'` returns zero hits. Removing the dependency trims the build graph with no behavior or API change.

## Verification

- `cargo check -p marigold-impl --all-features` — clean
- `cargo check --workspace` — clean
- No `pin_utils!` / `pin_utils::pin_mut` etc. references anywhere in `marigold-impl/src/`, `tests/`, or `benches/`.

## Precept

Aligns with the implicit "no dead deps" precept already exercised by prior arch passes (e.g. PR #145, #146).

---
_Generated by [Claude Code](https://claude.ai/code/session_014QXNr53WUnK5g2bLJkyE5E)_