### PR TITLE
arch: move serde_json to dev-dependencies in marigold-grammar

### DIFF
--- a/marigold-grammar/Cargo.toml
+++ b/marigold-grammar/Cargo.toml
@@ -21,11 +21,11 @@ arrayvec = "0.7"
 pest = "2.7"
 pest_derive = "2.7"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 proptest = "1"
+serde_json = "1"
 tempfile = "3"
 
 [[bench]]


### PR DESCRIPTION
## Summary

`serde_json` is currently a runtime dependency of `marigold-grammar`, but every reference in the crate sources lives inside `#[cfg(test)]` blocks (`marigold-grammar/src/complexity.rs:1374`, `:1376`, `:1594-95`, `:1656-58`, `:1665-67`, `:1676`, plus surrounding round-trip tests). No production code path serializes/deserializes JSON.

Moving it from `[dependencies]` to `[dev-dependencies]` removes `serde_json` (and its transitive deps) from downstream consumers' runtime build graph, with zero source changes.

## Verification

- `cargo check -p marigold-grammar --all-targets --all-features` — clean
- `cargo test -p marigold-grammar --lib` — 295 tests pass (unchanged)

## Precept

Aligns with the standard precept of declaring deps at the narrowest scope where they are needed — runtime deps should never be test-only. Reduces downstream compile cost without changing semantics.

---
_Generated by [Claude Code](https://claude.ai/code/session_014QXNr53WUnK5g2bLJkyE5E)_