### PR TITLE
arch: drop unused itertools dep and re-export from marigold-grammar

### DIFF
--- a/marigold-grammar/Cargo.toml
+++ b/marigold-grammar/Cargo.toml
@@ -15,7 +15,6 @@ async-std = []
 
 [dependencies]
 num-traits = "0.2"
-itertools = "0.10.2"
 num-bigint = "0.4"
 arrayvec = "0.7"
 pest = "2.7"

--- a/marigold-grammar/src/lib.rs
+++ b/marigold-grammar/src/lib.rs
@@ -64,8 +64,6 @@
 
 extern crate proc_macro;
 
-pub use itertools;
-
 pub mod bound_resolution;
 pub mod complexity;
 pub mod nodes;


### PR DESCRIPTION
## Summary

`marigold-grammar/src/lib.rs:67` exposes `pub use itertools;`, and `marigold-grammar/Cargo.toml` declares `itertools = "0.10.2"`. Both are dead:

- `grep -rn '\bitertools' marigold-grammar/src` shows only the `pub use` line itself — no source file in `marigold-grammar/` imports itertools.
- `grep -rn 'marigold_grammar::itertools'` across the workspace returns zero hits — no consumer (including `marigold`, `marigold-impl`, `marigold-macros`, `tests`, `examples/*`) goes through this re-export.
- `marigold-impl` carries its own direct itertools dep (used by `combinations.rs` / `permutations.rs`); dropping the grammar-level dep does not affect it.

This PR removes both the `pub use` and the dependency, shrinking the build graph and the public surface area.

## Verification

- `cargo check -p marigold-grammar --all-targets --all-features` — clean
- `cargo check --workspace` — clean
- `cargo test -p marigold-grammar --lib` — 295 tests pass

## Precept

Aligns with the standing precept to keep public re-exports minimal and not advertise dependencies that no consumer uses.

---
_Generated by [Claude Code](https://claude.ai/code/session_014QXNr53WUnK5g2bLJkyE5E)_