### PR TITLE
test: add coverage for MultiConsumerStream and RunFutureAsStream

### DIFF
--- a/marigold-impl/src/multi_consumer_stream.rs
+++ b/marigold-impl/src/multi_consumer_stream.rs
@@ -69,6 +69,9 @@ impl<
     }
 }
 
+// TODO: implement FusedStream for RunFutureAsStream; calling poll_next() after
+// Ready(None) re-polls the already-completed future, which is UB for some Future
+// implementations that don't guarantee poll-after-ready safety.
 pub struct RunFutureAsStream<T: Unpin, O, F: Future<Output = O>> {
     future: Pin<Box<F>>,
     t: PhantomData<T>,
@@ -102,9 +105,19 @@ impl<T: std::marker::Send + Unpin + 'static, O, F: Future<Output = O>> Stream
 }
 
 #[cfg(test)]
+// CI runs `cargo test` (inline path) and `cargo test --features tokio`
+// (spawn path), so both code paths are exercised by this suite.
 mod tests {
     use super::*;
     use futures::stream::{self, StreamExt};
+
+    // size_hint is synchronous; #[test] suffices.
+    #[test]
+    fn test_run_future_as_stream_size_hint() {
+        let fut = Box::pin(async { () });
+        let s: RunFutureAsStream<u32, (), _> = RunFutureAsStream::new(fut);
+        assert_eq!(s.size_hint(), (0, None));
+    }
 
     #[tokio::test]
     async fn test_run_future_as_stream_is_always_empty() {
@@ -114,16 +127,10 @@ mod tests {
         assert!(items.is_empty());
     }
 
+    // Items are silently dropped (and run() does not hang) when there are no receivers.
     #[tokio::test]
-    async fn test_run_future_as_stream_size_hint() {
-        let fut = Box::pin(async { () });
-        let s: RunFutureAsStream<u32, (), _> = RunFutureAsStream::new(fut);
-        assert_eq!(s.size_hint(), (0, None));
-    }
-
-    #[tokio::test]
-    async fn test_multi_consumer_stream_empty_source_no_receivers() {
-        let inner = stream::iter(Vec::<u32>::new());
+    async fn test_multi_consumer_stream_no_receivers_drops_items_silently() {
+        let inner = stream::iter(vec![1u32, 2, 3]);
         let mcs = MultiConsumerStream::new(inner);
         mcs.run().await;
     }
@@ -153,7 +160,8 @@ mod tests {
         let inner = stream::iter(items.clone());
         let mut mcs = MultiConsumerStream::new(inner);
         let rx = mcs.get();
-        // Spawn consumer concurrently to avoid deadlock with BUFFER_SIZE=1 in the inline path
+        // Spawn consumer first: with BUFFER_SIZE=1 the inline run() blocks on feed()
+        // until the consumer drains the buffer, requiring concurrent execution.
         let consumer = tokio::spawn(async move { rx.collect::<Vec<_>>().await });
         mcs.run().await;
         let received = consumer.await.unwrap();
@@ -176,10 +184,19 @@ mod tests {
         assert_eq!(received2, items);
     }
 
+    // Verifies run() completes cleanly when a receiver is dropped mid-stream.
+    // The production code discards feed() errors silently, so this must not hang.
     #[tokio::test]
-    async fn test_multi_consumer_stream_no_receivers_completes() {
-        let inner = stream::iter(vec![1u32, 2, 3]);
-        let mcs = MultiConsumerStream::new(inner);
-        mcs.run().await;
+    async fn test_multi_consumer_stream_receiver_dropped_mid_stream() {
+        let inner = stream::iter(vec![1u32, 2, 3, 4, 5]);
+        let mut mcs = MultiConsumerStream::new(inner);
+        let rx = mcs.get();
+        // Consumer reads exactly one item then drops, simulating a cancel or panic.
+        let consumer = tokio::spawn(async move {
+            let mut rx = rx;
+            let _ = rx.next().await;
+        });
+        mcs.run().await; // must complete without hanging
+        consumer.await.unwrap();
     }
 }

--- a/marigold-impl/src/multi_consumer_stream.rs
+++ b/marigold-impl/src/multi_consumer_stream.rs
@@ -100,3 +100,86 @@ impl<T: std::marker::Send + Unpin + 'static, O, F: Future<Output = O>> Stream
         (0, None)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream::{self, StreamExt};
+
+    #[tokio::test]
+    async fn test_run_future_as_stream_is_always_empty() {
+        let fut = Box::pin(async { 42u32 });
+        let s: RunFutureAsStream<u32, u32, _> = RunFutureAsStream::new(fut);
+        let items: Vec<u32> = s.collect().await;
+        assert!(items.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_run_future_as_stream_size_hint() {
+        let fut = Box::pin(async { () });
+        let s: RunFutureAsStream<u32, (), _> = RunFutureAsStream::new(fut);
+        assert_eq!(s.size_hint(), (0, None));
+    }
+
+    #[tokio::test]
+    async fn test_multi_consumer_stream_empty_source_no_receivers() {
+        let inner = stream::iter(Vec::<u32>::new());
+        let mcs = MultiConsumerStream::new(inner);
+        mcs.run().await;
+    }
+
+    #[tokio::test]
+    async fn test_multi_consumer_stream_empty_source_with_receiver() {
+        let inner = stream::iter(Vec::<u32>::new());
+        let mut mcs = MultiConsumerStream::new(inner);
+        let mut rx = mcs.get();
+        mcs.run().await;
+        assert!(rx.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_multi_consumer_stream_single_item_single_receiver() {
+        let inner = stream::iter(vec![42u32]);
+        let mut mcs = MultiConsumerStream::new(inner);
+        let mut rx = mcs.get();
+        mcs.run().await;
+        assert_eq!(rx.next().await, Some(42));
+        assert!(rx.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_multi_consumer_stream_multiple_items_single_receiver() {
+        let items = vec![1u32, 2, 3, 4, 5];
+        let inner = stream::iter(items.clone());
+        let mut mcs = MultiConsumerStream::new(inner);
+        let rx = mcs.get();
+        // Spawn consumer concurrently to avoid deadlock with BUFFER_SIZE=1 in the inline path
+        let consumer = tokio::spawn(async move { rx.collect::<Vec<_>>().await });
+        mcs.run().await;
+        let received = consumer.await.unwrap();
+        assert_eq!(received, items);
+    }
+
+    #[tokio::test]
+    async fn test_multi_consumer_stream_multiple_items_two_receivers() {
+        let items = vec![10u32, 20, 30];
+        let inner = stream::iter(items.clone());
+        let mut mcs = MultiConsumerStream::new(inner);
+        let rx1 = mcs.get();
+        let rx2 = mcs.get();
+        let consumer1 = tokio::spawn(async move { rx1.collect::<Vec<_>>().await });
+        let consumer2 = tokio::spawn(async move { rx2.collect::<Vec<_>>().await });
+        mcs.run().await;
+        let received1 = consumer1.await.unwrap();
+        let received2 = consumer2.await.unwrap();
+        assert_eq!(received1, items);
+        assert_eq!(received2, items);
+    }
+
+    #[tokio::test]
+    async fn test_multi_consumer_stream_no_receivers_completes() {
+        let inner = stream::iter(vec![1u32, 2, 3]);
+        let mcs = MultiConsumerStream::new(inner);
+        mcs.run().await;
+    }
+}


### PR DESCRIPTION
## Summary

`marigold-impl/src/multi_consumer_stream.rs` was the only source file in the crate with zero tests, making it the largest coverage gap.

- Adds 7 `#[tokio::test]` tests covering `RunFutureAsStream` and `MultiConsumerStream`
- Tests for `RunFutureAsStream`: always-empty collection, `size_hint` returns `(0, None)`
- Tests for `MultiConsumerStream`: empty source (with and without receivers), single-item single-receiver, multi-item single-receiver, multi-item two-receivers (broadcast), and no-receivers completion
- Multi-item tests spawn consumers with `tokio::spawn` before calling `run().await` to avoid deadlock caused by `BUFFER_SIZE = 1` when the inline (no runtime feature) code path is active

## Test plan

- [ ] `cargo test -p marigold-impl` passes locally and in CI
- [ ] All 7 new tests pass: `test_run_future_as_stream_*` (2) and `test_multi_consumer_stream_*` (5)
- [ ] No regressions in existing tests

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8jW4sRBch2qoRaWXnh4wb)_