### PR TITLE
test: add unit tests for multi_consumer_stream and writer

### DIFF
--- a/marigold-impl/src/multi_consumer_stream.rs
+++ b/marigold-impl/src/multi_consumer_stream.rs
@@ -100,3 +100,82 @@ impl<T: std::marker::Send + Unpin + 'static, O, F: Future<Output = O>> Stream
         (0, None)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream;
+    use futures::StreamExt;
+
+    #[tokio::test]
+    async fn test_empty_stream_no_items() {
+        let s = stream::iter(vec![] as Vec<u32>);
+        let mut mcs = MultiConsumerStream::new(s);
+        let mut rx = mcs.get();
+        mcs.run().await;
+        assert!(rx.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_single_receiver_collects_all_items() {
+        let s = stream::iter(vec![10u32, 20, 30]);
+        let mut mcs = MultiConsumerStream::new(s);
+        let mut rx = mcs.get();
+
+        // Run producer and consumer concurrently to avoid blocking on the
+        // bounded channel (BUFFER_SIZE = 1).
+        let (_, collected) = tokio::join!(
+            mcs.run(),
+            async move {
+                let mut out = vec![];
+                while let Some(v) = rx.next().await {
+                    out.push(v);
+                }
+                out
+            }
+        );
+        assert_eq!(collected, vec![10u32, 20, 30]);
+    }
+
+    #[tokio::test]
+    async fn test_two_receivers_each_get_all_items() {
+        let s = stream::iter(vec![1u32, 2, 3]);
+        let mut mcs = MultiConsumerStream::new(s);
+        let mut rx1 = mcs.get();
+        let mut rx2 = mcs.get();
+
+        let collect1 = async move {
+            let mut out = vec![];
+            while let Some(v) = rx1.next().await {
+                out.push(v);
+            }
+            out
+        };
+        let collect2 = async move {
+            let mut out = vec![];
+            while let Some(v) = rx2.next().await {
+                out.push(v);
+            }
+            out
+        };
+
+        let (_, c1, c2) = tokio::join!(mcs.run(), collect1, collect2);
+        assert_eq!(c1, vec![1u32, 2, 3]);
+        assert_eq!(c2, vec![1u32, 2, 3]);
+    }
+
+    #[tokio::test]
+    async fn test_run_future_as_stream_yields_nothing() {
+        let fut = Box::pin(async { 42u32 });
+        let mut stream: RunFutureAsStream<u32, u32, _> = RunFutureAsStream::new(fut);
+        let result = stream.next().await;
+        assert!(result.is_none(), "RunFutureAsStream should never yield items");
+    }
+
+    #[test]
+    fn test_run_future_as_stream_size_hint() {
+        let fut = Box::pin(async { () });
+        let stream: RunFutureAsStream<u32, (), _> = RunFutureAsStream::new(fut);
+        assert_eq!(stream.size_hint(), (0, None));
+    }
+}

--- a/marigold-impl/src/multi_consumer_stream.rs
+++ b/marigold-impl/src/multi_consumer_stream.rs
@@ -109,7 +109,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_empty_stream_no_items() {
-        let s = stream::iter(vec![] as Vec<u32>);
+        let s = stream::iter(Vec::<u32>::new());
         let mut mcs = MultiConsumerStream::new(s);
         let mut rx = mcs.get();
         mcs.run().await;
@@ -121,7 +121,6 @@ mod tests {
         let s = stream::iter(vec![10u32, 20, 30]);
         let mut mcs = MultiConsumerStream::new(s);
         let mut rx = mcs.get();
-
         // Run producer and consumer concurrently to avoid blocking on the
         // bounded channel (BUFFER_SIZE = 1).
         let (_, collected) = tokio::join!(
@@ -169,7 +168,7 @@ mod tests {
         let fut = Box::pin(async { 42u32 });
         let mut stream: RunFutureAsStream<u32, u32, _> = RunFutureAsStream::new(fut);
         let result = stream.next().await;
-        assert!(result.is_none(), "RunFutureAsStream should never yield items");
+        assert!(result.is_none());
     }
 
     #[test]

--- a/marigold-impl/src/multi_consumer_stream.rs
+++ b/marigold-impl/src/multi_consumer_stream.rs
@@ -131,7 +131,7 @@ mod tests {
                     out.push(v);
                 }
                 out
-            }
+            },
         );
         assert_eq!(collected, vec![10u32, 20, 30]);
     }

--- a/marigold-impl/src/writer.rs
+++ b/marigold-impl/src/writer.rs
@@ -59,3 +59,46 @@ impl tokio::io::AsyncWrite for Writer {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::AsyncWriteExt;
+
+    #[tokio::test]
+    async fn test_vector_writer_write_all() {
+        let mut w = Writer::vector();
+        w.write_all(b"hello world").await.unwrap();
+        w.flush().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_vector_writer_empty_write() {
+        let mut w = Writer::vector();
+        w.write_all(b"").await.unwrap();
+        w.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_vector_writer_multiple_writes_then_shutdown() {
+        let mut w = Writer::vector();
+        w.write_all(b"foo").await.unwrap();
+        w.write_all(b"bar").await.unwrap();
+        w.flush().await.unwrap();
+        w.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_file_writer_write_and_read_back() {
+        let path = std::env::temp_dir()
+            .join(format!("marigold_writer_test_{}.tmp", std::process::id()));
+        let file = tokio::fs::File::create(&path).await.unwrap();
+        let mut w = Writer::file(file);
+        w.write_all(b"test content").await.unwrap();
+        w.flush().await.unwrap();
+        w.shutdown().await.unwrap();
+        let content = tokio::fs::read(&path).await.unwrap();
+        assert_eq!(content, b"test content");
+        tokio::fs::remove_file(&path).await.unwrap();
+    }
+}


### PR DESCRIPTION
## Summary

- `marigold-impl/src/multi_consumer_stream.rs` and `marigold-impl/src/writer.rs` were the two completely untested modules in marigold-impl (0% coverage per Codecov)
- Added `#[cfg(test)]` modules to both files covering all public API surface

**multi_consumer_stream.rs** tests:
- `test_empty_stream_no_items` — receiver closes immediately when the stream is empty
- `test_single_receiver_collects_all_items` — fan-out to one receiver delivers all items in order
- `test_two_receivers_each_get_all_items` — fan-out to two receivers both receive every item
- `test_run_future_as_stream_yields_nothing` — `RunFutureAsStream` yields `None` when the inner future resolves
- `test_run_future_as_stream_size_hint` — `size_hint()` returns `(0, None)`

**writer.rs** tests:
- `test_vector_writer_write_all` — write bytes through `Writer::vector()`
- `test_vector_writer_empty_write` — zero-byte write doesn't error
- `test_vector_writer_multiple_writes_then_shutdown` — sequential writes + flush + shutdown
- `test_file_writer_write_and_read_back` — write via `Writer::file()` and verify content persisted

## Test plan

- [ ] `cargo test -p marigold-impl` passes
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpV9fMEdB4ePFStRi7NR8e)_