### PR TITLE
arch: gate anyhow dependency on the cli feature

### DIFF
--- a/marigold/Cargo.toml
+++ b/marigold/Cargo.toml
@@ -11,10 +11,10 @@ repository = "https://github.com/DominicBurkart/marigold"
 tokio = ["marigold-impl/tokio", "marigold-grammar/tokio"]
 async-std = ["marigold-impl/async-std", "marigold-grammar/async-std"]
 io = ["marigold-impl/io", "marigold-grammar/io", "marigold-macros/io"]
-cli = ["clap", "convert_case", "home", "serde_json"]
+cli = ["anyhow", "clap", "convert_case", "home", "serde_json"]
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { version = "1.0", optional = true }
 clap = { version = "4.0.27", features = ["derive"], optional = true }
 convert_case = { version="0.6.0", optional = true }
 home = { version = "0.5.4", optional = true }


### PR DESCRIPTION
## Summary

`anyhow` is only referenced under `#[cfg(feature = "cli")]` in `marigold/src/main.rs`:
- line 2: `use anyhow::Result;`
- line 158: `.map_err(|e| anyhow::anyhow!("{}", e))?`

Both are inside `cfg(feature = "cli")` blocks. The non-CLI `fn main()` (lines 51-54) does not use `anyhow`. Marking the dep `optional = true` and adding it to the `cli` feature list eliminates a transitive compile for `cargo build -p marigold --no-default-features` / library consumers that don't enable `cli`.

## Diff

`marigold/Cargo.toml`:
- `cli = [...]` gains `"anyhow"` at the front.
- `anyhow = "1.0"` becomes `anyhow = { version = "1.0", optional = true }`.

No source changes; existing `#[cfg(feature = "cli")] use anyhow::Result;` and the `anyhow::anyhow!` call already gate the references.

## Verification

- `cargo check -p marigold --no-default-features` — clean.
- `cargo check -p marigold --no-default-features --features cli` — clean.

## Test plan

- [ ] CI: workspace build/test green
- [ ] CI: `cargo check -p marigold --no-default-features` green
- [ ] CI: `cargo check -p marigold --features cli` green

https://claude.ai/code/session_01XpmLwG91zKyKJcoBg1nWjb

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpmLwG91zKyKJcoBg1nWjb)_