### PR TITLE
docs: fix README quick-start example to match working doctest

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ Rust programs.
 use marigold::m;
 
 let odd_digits = m!(
-  fn is_odd(i: &i32) -> bool {
+  fn is_odd(i: i32) -> bool {
     i.wrapping_rem(2) == 1
   }
 
   range(0, 10)
     .filter(is_odd)
     .return
-).await.collect::<Vec<_>>();
+).await.collect::<Vec<_>>().await;
 
 println!("{:?}", odd_digits); // [1, 3, 5, 7, 9]
 ```

--- a/marigold/README.md
+++ b/marigold/README.md
@@ -20,14 +20,14 @@ Rust programs.
 use marigold::m;
 
 let odd_digits = m!(
-  fn is_odd(i: &i32) -> bool {
+  fn is_odd(i: i32) -> bool {
     i.wrapping_rem(2) == 1
   }
 
   range(0, 10)
     .filter(is_odd)
     .return
-).await.collect::<Vec<_>>();
+).await.collect::<Vec<_>>().await;
 
 println!("{:?}", odd_digits); // [1, 3, 5, 7, 9]
 ```


### PR DESCRIPTION
## Summary

The Rust snippet in the top-level `README.md` (and the duplicate inside `marigold/README.md`) diverged from the verified doctest in `marigold/src/lib.rs` in two ways:

- The predicate was declared `fn is_odd(i: &i32) -> bool`, but every working call site in the codebase (the `lib.rs` doctest, `examples/multi-consumer/src/main.rs`, `tests/src/lib.rs`) declares it as `fn is_odd(i: i32) -> bool`. The macro injects the borrow when `filter` is applied.
- The chain ended with `.await.collect::<Vec<_>>()`, missing the final `.await` that the `Stream::collect` future requires. As written, `odd_digits` would be a future, not the printed `Vec`.

This PR aligns both READMEs with the canonical, tested form so that a reader who copies the snippet gets working code that produces `[1, 3, 5, 7, 9]` as documented.

## Why functionality is preserved

Documentation-only change. No source files, tests, CI, or build configuration are modified. The codecov badge URL (also incorrect) is intentionally left untouched here so that this PR is a focused fix; it is addressed in a separate PR.

## Test plan

- [ ] Visually inspect the rendered README on the PR page.
- [ ] Confirm the snippet matches the doctest in `marigold/src/lib.rs`, which is exercised by `cargo test`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01173Smn5AbVSYT2cT3QKuNN)_