### PR TITLE
test(writer): add comprehensive tests for Writer — 0% → ~100% coverage

### DIFF
--- a/marigold-impl/src/writer.rs
+++ b/marigold-impl/src/writer.rs
@@ -59,3 +59,110 @@ impl tokio::io::AsyncWrite for Writer {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::AsyncWriteExt;
+
+    fn unique_temp_path(prefix: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!(
+            "marigold_{prefix}_{pid}_{n}.tmp",
+            pid = std::process::id()
+        ))
+    }
+
+    #[tokio::test]
+    async fn vector_write_all() {
+        let mut w = Writer::vector();
+        w.write_all(b"hello").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn vector_flush() {
+        let mut w = Writer::vector();
+        w.write_all(b"data").await.unwrap();
+        w.flush().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn vector_shutdown() {
+        let mut w = Writer::vector();
+        w.write_all(b"end").await.unwrap();
+        w.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn vector_empty_write() {
+        let mut w = Writer::vector();
+        w.write_all(b"").await.unwrap();
+        w.flush().await.unwrap();
+        w.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn vector_multiple_writes() {
+        let mut w = Writer::vector();
+        for _ in 0..5 {
+            w.write_all(b"chunk").await.unwrap();
+        }
+        w.flush().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn vector_retains_written_data() {
+        let mut writer = Writer::vector();
+        writer.write_all(b"hello world").await.unwrap();
+        match &writer.inner {
+            WriteTarget::Vector(v) => {
+                assert_eq!(v.as_ref().get_ref().as_slice(), b"hello world");
+            }
+            WriteTarget::File(_) => panic!("expected Vector"),
+        }
+    }
+
+    #[tokio::test]
+    async fn file_write_flush_and_verify() {
+        let path = unique_temp_path("writer_file");
+        let file = tokio::fs::File::create(&path).await.unwrap();
+        let mut writer = Writer::file(file);
+        writer.write_all(b"file content").await.unwrap();
+        writer.flush().await.unwrap();
+        writer.shutdown().await.unwrap();
+        drop(writer);
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(content, "file content");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn file_multiple_writes_and_verify() {
+        let path = unique_temp_path("writer_multi");
+        let file = tokio::fs::File::create(&path).await.unwrap();
+        let mut writer = Writer::file(file);
+        writer.write_all(b"part1 ").await.unwrap();
+        writer.write_all(b"part2").await.unwrap();
+        writer.flush().await.unwrap();
+        drop(writer);
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(content, "part1 part2");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn file_empty_write() {
+        let path = unique_temp_path("writer_empty");
+        let file = tokio::fs::File::create(&path).await.unwrap();
+        let mut writer = Writer::file(file);
+        writer.write_all(b"").await.unwrap();
+        writer.flush().await.unwrap();
+        writer.shutdown().await.unwrap();
+        drop(writer);
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(content, "");
+        let _ = std::fs::remove_file(&path);
+    }
+}


### PR DESCRIPTION
## Summary

`marigold-impl/src/writer.rs` was the single largest uncovered file in the repo (100% uncovered — every line, every branch). This PR adds a `#[cfg(test)] mod tests` block covering all code paths.

### What's covered
- `Writer::vector()` constructor and all three `AsyncWrite` poll methods (`poll_write`, `poll_flush`, `poll_shutdown`) via `write_all`, `flush`, `shutdown`
- `Writer::file()` constructor and the same three poll methods via round-trip file I/O
- Empty writes, multiple sequential writes, shutdown after flush
- Internal data-retention: accesses `WriteTarget::Vector(v)` directly (only possible from inline tests) to assert the byte slice matches what was written

### Notes
- Tests are gated behind `#[cfg(test)]` and only compile when the `io` feature is active, matching the CI matrix (`cargo test --features tokio,io` and `--all-features`)
- Unique temp-file names via `AtomicU64 + process::id()` prevent parallelism conflicts in the file-backed tests

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGXms74FqDQHNiDBCTP6eQ)_