### PR TITLE
test(writer): add unit tests for Writer AsyncWrite implementation

### DIFF
--- a/marigold-impl/Cargo.toml
+++ b/marigold-impl/Cargo.toml
@@ -42,6 +42,7 @@ tokio = { version = "1", features = ["full"]}
 criterion = { version = "0.5", features = ["html_reports"] }
 cpu-time = "1.0"
 tracing-subscriber = { version = "0.3", features = ["registry"] }
+tempfile = "3"
 
 [[bench]]
 name = "keep_first_n"

--- a/marigold-impl/src/writer.rs
+++ b/marigold-impl/src/writer.rs
@@ -59,3 +59,93 @@ impl tokio::io::AsyncWrite for Writer {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::AsyncWriteExt;
+
+    #[tokio::test]
+    async fn writer_vector_write_succeeds() {
+        let mut w = Writer::vector();
+        let n = w.write(b"hello").await.unwrap();
+        assert_eq!(n, 5);
+    }
+
+    #[tokio::test]
+    async fn writer_vector_flush_succeeds() {
+        let mut w = Writer::vector();
+        w.flush().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn writer_vector_shutdown_succeeds() {
+        let mut w = Writer::vector();
+        w.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn writer_vector_empty_write() {
+        let mut w = Writer::vector();
+        let n = w.write(b"").await.unwrap();
+        assert_eq!(n, 0);
+    }
+
+    #[tokio::test]
+    async fn writer_vector_multiple_sequential_writes() {
+        let mut w = Writer::vector();
+        w.write_all(b"foo").await.unwrap();
+        w.write_all(b"bar").await.unwrap();
+        w.flush().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn writer_vector_debug_contains_variant_name() {
+        let w = Writer::vector();
+        assert!(format!("{:?}", w).contains("Vector"));
+    }
+
+    #[tokio::test]
+    async fn writer_file_write_and_read_back() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.bin");
+        let f = tokio::fs::File::create(&path).await.unwrap();
+        let mut w = Writer::file(f);
+        w.write_all(b"hello file").await.unwrap();
+        w.shutdown().await.unwrap();
+        let contents = tokio::fs::read(&path).await.unwrap();
+        assert_eq!(contents, b"hello file");
+    }
+
+    #[tokio::test]
+    async fn writer_file_empty_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty.bin");
+        let f = tokio::fs::File::create(&path).await.unwrap();
+        let mut w = Writer::file(f);
+        let n = w.write(b"").await.unwrap();
+        assert_eq!(n, 0);
+    }
+
+    #[tokio::test]
+    async fn writer_file_multiple_writes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("multi.bin");
+        let f = tokio::fs::File::create(&path).await.unwrap();
+        let mut w = Writer::file(f);
+        w.write_all(b"abc").await.unwrap();
+        w.write_all(b"def").await.unwrap();
+        w.shutdown().await.unwrap();
+        let contents = tokio::fs::read(&path).await.unwrap();
+        assert_eq!(contents, b"abcdef");
+    }
+
+    #[tokio::test]
+    async fn writer_file_debug_contains_variant_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("debug.bin");
+        let f = tokio::fs::File::create(&path).await.unwrap();
+        let w = Writer::file(f);
+        assert!(format!("{:?}", w).contains("File"));
+    }
+}


### PR DESCRIPTION
Closing as superseded by #261, which includes this PR's writer tests (Workstream 2) plus two additional workstreams (codecov badge fix, code-gen dedup). All of #261's CI is green; #260's Benches check is failing. No work is lost.